### PR TITLE
Add commit lint as a Github action

### DIFF
--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [ pull_request ]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "imx-core-sdk-swift",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Commits will be inspected in order to follow the defined standard for the repository, which is Conventional Commits
https://www.conventionalcommits.org/en/v1.0.0/

Also, set minimum version to iOS 13 and macOS 10.15. iOS 13 covers more than 95% of active users and macOS 10.15 (Catalina) covers about 85% of active users. These versions also enable us to use Swift's Async/Await in backwards compatibility mode.