### PR TITLE
Rename package to IMXCoreSDK and setup SwiftLint

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,22 @@
+name: SwiftLint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/swiftlint.yml'
+      - '.swiftlint.yml'
+      - '**/*.swift'
+
+jobs:
+  SwiftLint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: sinoru/actions-setup-swift@v2
+        with:
+          swift-version: '5.6.1'
+      - name: GitHub Actions for SwiftLint with --strict
+        uses: sinoru/actions-swiftlint@v6
+        with:
+          swiftlint-args: --strict
+          working-directory: Sources

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,3 @@
+excluded:
+  - Pods
+  - Packages

--- a/.swiftpm/xcode/xcshareddata/xcschemes/IMXCoreSDK.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/IMXCoreSDK.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "IMXCoreSDK"
+               BuildableName = "IMXCoreSDK"
+               BlueprintName = "IMXCoreSDK"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "IMXCoreSDKTests"
+               BuildableName = "IMXCoreSDKTests"
+               BlueprintName = "IMXCoreSDKTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SwiftLintXcode"
+               BuildableName = "SwiftLintXcode"
+               BlueprintName = "SwiftLintXcode"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "IMXCoreSDKTests"
+               BuildableName = "IMXCoreSDKTests"
+               BlueprintName = "IMXCoreSDKTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "IMXCoreSDK"
+            BuildableName = "IMXCoreSDK"
+            BlueprintName = "IMXCoreSDK"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// swiftlint:disable line_length
 
 import PackageDescription
 
@@ -7,23 +8,34 @@ let package = Package(
     name: "IMXCoreSDK",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_15),
+        .macOS(.v10_15)
     ],
     products: [
         .library(
             name: "IMXCoreSDK",
             targets: ["IMXCoreSDK"]
-        ),
+        )
     ],
     dependencies: [],
     targets: [
+        .binaryTarget(
+            name: "SwiftLintBinary",
+            url: "https://github.com/juozasvalancius/SwiftLint/releases/download/spm-accommodation/SwiftLintBinary-macos.artifactbundle.zip",
+            checksum: "cdc36c26225fba80efc3ac2e67c2e3c3f54937145869ea5dbcaa234e57fc3724"
+        ),
+        .plugin(
+            name: "SwiftLintXcode",
+            capability: .buildTool(),
+            dependencies: ["SwiftLintBinary"]
+        ),
         .target(
             name: "IMXCoreSDK",
-            dependencies: []
+            dependencies: [],
+            plugins: ["SwiftLintXcode"]
         ),
         .testTarget(
             name: "IMXCoreSDKTests",
             dependencies: ["IMXCoreSDK"]
-        ),
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,32 +4,26 @@
 import PackageDescription
 
 let package = Package(
-    name: "imx-core-sdk-swift",
+    name: "IMXCoreSDK",
     platforms: [
         .iOS(.v13),
         .macOS(.v10_15),
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "imx-core-sdk-swift",
-            targets: ["imx-core-sdk-swift"]
+            name: "IMXCoreSDK",
+            targets: ["IMXCoreSDK"]
         ),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "imx-core-sdk-swift",
+            name: "IMXCoreSDK",
             dependencies: []
         ),
         .testTarget(
-            name: "imx-core-sdk-swiftTests",
-            dependencies: ["imx-core-sdk-swift"]
+            name: "IMXCoreSDKTests",
+            dependencies: ["IMXCoreSDK"]
         ),
     ]
 )

--- a/Plugins/SwiftLintXcode/plugin.swift
+++ b/Plugins/SwiftLintXcode/plugin.swift
@@ -1,0 +1,22 @@
+import PackagePlugin
+
+// Plugin setup from https://github.com/juozasvalancius/ExampleSPMProjectWithSwiftLint
+@main
+struct SwiftLintPlugins: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        return [
+            .buildCommand(
+                displayName: "Linting \(target.name)",
+                executable: try context.tool(named: "swiftlint").path,
+                arguments: [
+                    "lint",
+                    "--in-process-sourcekit", // alternative to the environment variable
+                    "--path",
+                    target.directory.string   // only lint the files in the target directory
+                ],
+                // environment: ["IN_PROCESS_SOURCEKIT": "YES"] // doesn't work in Xcode 13.3
+                environment: [:]
+            )
+        ]
+    }
+}

--- a/Sources/IMXCoreSDK/IMXCoreSDK.swift
+++ b/Sources/IMXCoreSDK/IMXCoreSDK.swift
@@ -1,4 +1,4 @@
-public struct imx_core_sdk_swift {
+public struct IMXCoreSDK {
     public private(set) var text = "Hello, World!"
 
     public init() {

--- a/Tests/IMXCoreSDKTests/IMXCoreSDKTests.swift
+++ b/Tests/IMXCoreSDKTests/IMXCoreSDKTests.swift
@@ -1,11 +1,11 @@
 import XCTest
-@testable import imx_core_sdk_swift
+@testable import IMXCoreSDK
 
-final class imx_core_sdk_swiftTests: XCTestCase {
+final class IMXCoreSDKTests: XCTestCase {
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
         // results.
-        XCTAssertEqual(imx_core_sdk_swift().text, "Hello, World!")
+        XCTAssertEqual(IMXCoreSDK().text, "Hello, World!")
     }
 }


### PR DESCRIPTION
The repository follows IMX's SDKs standard naming convention, but the Swift package itself should follow the language's standard, which is PascalCase. The "Swift" suffix was also dropped for being redundant.

Usage example:

```swift
import IMXCoreSDK
```

Also, integrate SwiftLint in the package (a bit of a workaround was required since packages dont have build phase scripts) and set it up as a Github Action. Here's an example of what it looks like.
![swiftlint](https://user-images.githubusercontent.com/662062/176347705-38cd144a-2735-4e9a-977b-bef6c0d1e910.png)

Github Action picking up a lint issue:
<img width="846" alt="Github Action" src="https://user-images.githubusercontent.com/662062/176357754-31d2e1b2-01f7-4794-9d67-e92089d8fee5.png">

