### PR TITLE
StarkCurve + Private and Public Keys

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,6 @@
 disabled_rules:
-  trailing_comma
+  - trailing_comma
+  - identifier_name # Lots of math operations are written with short variable names as a standard
 excluded:
   - .build
   - Pods

--- a/Package.resolved
+++ b/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "f9fda69a7b704d46fb5123005f2f7e43dbb8a0fa",
         "version" : "0.6.5"
       }
+    },
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt",
+      "state" : {
+        "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+        "version" : "5.3.0"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
             url: "https://github.com/Flight-School/AnyCodable",
             from: "0.6.5"
         ),
+        .package(url: "https://github.com/attaswift/BigInt", from: "5.3.0"),
     ],
     targets: [
         .binaryTarget(
@@ -35,7 +36,7 @@ let package = Package(
         ),
         .target(
             name: "ImmutableXCore",
-            dependencies: ["AnyCodable"],
+            dependencies: ["AnyCodable", "BigInt"],
             resources: [
                 .copy("version"),
             ],

--- a/Sources/ImmutableXCore/Crypto/Keys/KeyPair.swift
+++ b/Sources/ImmutableXCore/Crypto/Keys/KeyPair.swift
@@ -1,0 +1,13 @@
+import BigInt
+import Foundation
+
+/// Elliptic Curve generated key pair containing a ``PrivateKey`` and a ``PublicKey``
+public struct KeyPair: Equatable {
+    public let privateKey: PrivateKey
+    public let publicKey: PublicKey
+
+    public init(private: PrivateKey, public: PublicKey) {
+        privateKey = `private`
+        publicKey = `public`
+    }
+}

--- a/Sources/ImmutableXCore/Crypto/Keys/PrivateKey.swift
+++ b/Sources/ImmutableXCore/Crypto/Keys/PrivateKey.swift
@@ -1,0 +1,24 @@
+import BigInt
+import Foundation
+
+/// Elliptic Curve generated private key
+public struct PrivateKey: Equatable {
+    public let number: BigInt
+
+    public var asData: Data {
+        number.as256bitLongData()
+    }
+
+    public init(number: BigInt) throws {
+        // Private Key must be in the curve range
+        guard case 1 ..< StarkCurve.N = number else { throw KeyError.invalidData }
+        self.number = number
+    }
+
+    public init(hex: String) throws {
+        guard let number = BigInt(hexString: hex) else {
+            throw KeyError.invalidData
+        }
+        try self.init(number: number)
+    }
+}

--- a/Sources/ImmutableXCore/Crypto/Keys/PublicKey.swift
+++ b/Sources/ImmutableXCore/Crypto/Keys/PublicKey.swift
@@ -1,0 +1,25 @@
+import BigInt
+import Foundation
+
+/// Elliptic Curve generated public key
+public struct PublicKey: Equatable {
+    public let point: CurvePoint
+    public let compressedData: Data
+
+    public var compressedHex: String {
+        compressedData.asHexString()
+    }
+
+    public init(point: CurvePoint) throws {
+        self.point = point
+        compressedData = Data(point.y.isEven ? [0x02] : [0x03]) + point.x.as256bitLongData()
+    }
+
+    public init(privateKey: PrivateKey) throws {
+        try self.init(point: StarkCurve.multiplyG(by: privateKey.number))
+    }
+
+    public static func == (lhs: PublicKey, rhs: PublicKey) -> Bool {
+        lhs.point == rhs.point
+    }
+}

--- a/Sources/ImmutableXCore/Crypto/Stark/CurvePoint.swift
+++ b/Sources/ImmutableXCore/Crypto/Stark/CurvePoint.swift
@@ -1,0 +1,13 @@
+import BigInt
+import Foundation
+
+/// A representation of an Affine Elliptic Curve Point
+public struct CurvePoint: Equatable {
+    public let x: BigInt
+    public let y: BigInt
+
+    public init(x: BigInt, y: BigInt) {
+        self.x = x
+        self.y = y
+    }
+}

--- a/Sources/ImmutableXCore/Crypto/Stark/StarkCurve.swift
+++ b/Sources/ImmutableXCore/Crypto/Stark/StarkCurve.swift
@@ -1,0 +1,128 @@
+import BigInt
+import Foundation
+
+/// Stark-friendly elliptic curve
+///
+/// The Stark-friendly elliptic curve used is defined as follows:
+///
+/// `y² ≡ x³ + α ⋅ x + β(modp)`
+///
+/// where:
+///
+/// ```
+/// α = 1
+/// β = 3141592653589793238462643383279502884197169399375105820974944592307816406665
+/// p = 3618502788666131213697322783095070105623107215331596699973092056135872020481
+///   = 2²⁵¹ + 17 ⋅ 2¹⁹² + 1
+/// ```
+///
+/// The Generator point used in the ECDSA scheme is:
+/// ```
+/// G = (874739451078007766457464989774322083649278607533249481151382481072868806602,
+///     152666792071518830868575557812948353041420400780739481342941381225525861407)
+/// ```
+/// https://docs.starkware.co/starkex-v4/crypto/stark-curve
+struct StarkCurve {
+    static let P = BigInt("3618502788666131213697322783095070105623107215331596699973092056135872020481")
+    static let N = BigInt("3618502788666131213697322783095070105526743751716087489154079457884512865583")
+
+    static let a = BigInt(1)
+    static let b = BigInt("3141592653589793238462643383279502884197169399375105820974944592307816406665")
+
+    static let G = CurvePoint(
+        x: BigInt("874739451078007766457464989774322083649278607533249481151382481072868806602"),
+        y: BigInt("152666792071518830868575557812948353041420400780739481342941381225525861407")
+    )
+}
+
+// MARK: - Division
+
+extension StarkCurve {
+    /// Return the result of ``number`` modulus ``StarkCurve.N``.
+    /// The result is always a nonnegative integer that is less than the absolute value of ``number``.
+    static func modN(_ number: BigInt) -> BigInt {
+        number.modulus(N)
+    }
+
+    /// Return the result of ``number`` modulus ``StarkCurve.P``.
+    /// The result is always a nonnegative integer that is less than the absolute value of ``number``.
+    static func modP(_ number: BigInt) -> BigInt {
+        number.modulus(P)
+    }
+
+    /// Return the result of ``dividend`` modulus ``StarkCurve.N`` times ``dividend`` modulus ``StarkCurve.N``.
+    static func modInverseN(_ dividend: BigInt, _ divisor: BigInt) -> BigInt {
+        divide(dividend, by: divisor, mod: N)
+    }
+
+    /// Return the result of ``dividend`` modulus ``StarkCurve.P`` times ``dividend`` modulus ``StarkCurve.P``.
+    static func modInverseP(_ dividend: BigInt, _ divisor: BigInt) -> BigInt {
+        divide(dividend, by: divisor, mod: P)
+    }
+
+    /// Return the result of ``dividend`` modulus ``mod`` times ``dividend`` modulus ``mod``.
+    static func divide(_ dividend: BigInt, by divisor: BigInt, mod: BigInt) -> BigInt {
+        let d1 = dividend > 0 ? dividend : dividend + mod
+        let d2 = divisor > 0 ? divisor : divisor + mod
+        return (d2.inverse(mod)! * d1).modulus(mod)
+    }
+}
+
+// MARK: - CurvePoint
+
+extension StarkCurve {
+    /// Adds given points ``p1`` and ``p2`` if different, otherwise doubles them
+    /// https://crypto.stanford.edu/pbc/notes/elliptic/explicit.html
+    static func addition(_ p1: CurvePoint?, _ p2: CurvePoint?) -> CurvePoint? {
+        guard let p1 = p1 else { return p2 }
+        guard let p2 = p2 else { return p1 }
+
+        if p1.x == p2.x, p1.y != p2.y {
+            return nil
+        }
+
+        if p1 == p2 {
+            return doublePoint(p1)
+        } else {
+            return addPoint(p1, to: p2)
+        }
+    }
+
+    /// Multiplies the given ``point`` by ``number``
+    /// https://crypto.stanford.edu/pbc/notes/elliptic/explicit.html
+    static func multiply(_ point: CurvePoint, by number: BigInt) -> CurvePoint {
+        var P: CurvePoint? = point
+        var r: CurvePoint!
+
+        for i in 0 ..< number.magnitude.bitWidth {
+            if number.magnitude[bitAt: i] {
+                r = addition(r, P)
+            }
+            P = addition(P, P)
+        }
+        return r
+    }
+
+    /// Multiplies ``StarkCurve.G`` point by given ``number``
+    static func multiplyG(by number: BigInt) -> CurvePoint {
+        multiply(StarkCurve.G, by: number)
+    }
+
+    /// Adds given points ``p1`` and ``p2``
+    /// https://crypto.stanford.edu/pbc/notes/elliptic/explicit.html
+    private static func addPoint(_ p1: CurvePoint, to p2: CurvePoint) -> CurvePoint {
+        let mipResult = modInverseP(p2.y - p1.y, p2.x - p1.x)
+        let x3 = modP(mipResult * mipResult - p1.x - p2.x)
+        let y3 = modP(mipResult * (p1.x - x3) - p1.y)
+        return CurvePoint(x: x3, y: y3)
+    }
+
+    /// Doubles the given point ``p`` based on ``StarkCurve.a``
+    /// https://crypto.stanford.edu/pbc/notes/elliptic/explicit.html
+    private static func doublePoint(_ p: CurvePoint) -> CurvePoint {
+        let mipResult = modInverseP(3 * (p.x * p.x) + StarkCurve.a, 2 * p.y)
+        let x3 = modP(mipResult * mipResult - 2 * p.x)
+        let y3 = modP(mipResult * (p.x - x3) - p.y)
+        return CurvePoint(x: x3, y: y3)
+    }
+}

--- a/Sources/ImmutableXCore/Extensions/Array+Extensions.swift
+++ b/Sources/ImmutableXCore/Extensions/Array+Extensions.swift
@@ -1,0 +1,52 @@
+// https://github.com/krzyzanowskim/CryptoSwift/blob/main/Sources/CryptoSwift/Array%2BExtension.swift#L34
+public extension Array where Element == UInt8 {
+    @inlinable
+    internal init(reserveCapacity: Int) {
+        self = [Element]()
+        self.reserveCapacity(reserveCapacity)
+    }
+
+    init(hex: String) {
+        self.init(reserveCapacity: hex.unicodeScalars.lazy.underestimatedCount)
+        var buffer: UInt8?
+        var skip = hex.hasPrefix("0x") ? 2 : 0
+
+        for char in hex.unicodeScalars.lazy {
+            guard skip == 0 else {
+                skip -= 1
+                continue
+            }
+
+            guard char.value >= 48, char.value <= 102 else {
+                removeAll()
+                return
+            }
+
+            let v: UInt8
+            let c = UInt8(char.value)
+
+            switch c {
+            case let c where c <= 57:
+                v = c - 48
+            case let c where c >= 65 && c <= 70:
+                v = c - 55
+            case let c where c >= 97:
+                v = c - 87
+            default:
+                removeAll()
+                return
+            }
+
+            if let b = buffer {
+                append(b << 4 | v)
+                buffer = nil
+            } else {
+                buffer = v
+            }
+        }
+
+        if let b = buffer {
+            append(b)
+        }
+    }
+}

--- a/Sources/ImmutableXCore/Extensions/BigInt+Extensions.swift
+++ b/Sources/ImmutableXCore/Extensions/BigInt+Extensions.swift
@@ -1,0 +1,29 @@
+import BigInt
+import Foundation
+
+public extension BigInt {
+    var isEven: Bool {
+        magnitude[bitAt: 0] == false
+    }
+
+    init?(hexString: String) {
+        self.init(hexString.dropHexPrefix, radix: 16)
+    }
+
+    func asString(uppercased: Bool = false, radix: Int) -> String {
+        let stringRepresentation = String(self, radix: radix)
+        return uppercased ? stringRepresentation.uppercased() : stringRepresentation
+    }
+
+    func asHexStringLength64(uppercased: Bool = false) -> String {
+        var hexString = asString(uppercased: uppercased, radix: 16)
+        while hexString.count < 64 {
+            hexString = "0\(hexString)"
+        }
+        return hexString
+    }
+
+    func as256bitLongData() -> Data {
+        asHexStringLength64().hexToData()
+    }
+}

--- a/Sources/ImmutableXCore/Extensions/Data+Extensions.swift
+++ b/Sources/ImmutableXCore/Extensions/Data+Extensions.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public extension Data {
+    func asHexString() -> String {
+        lazy.reduce(into: "") {
+            var s = String($1, radix: 16)
+            if s.count == 1 {
+                s = "0" + s
+            }
+            $0 += s
+        }
+    }
+}

--- a/Sources/ImmutableXCore/Extensions/Int+Extensions.swift
+++ b/Sources/ImmutableXCore/Extensions/Int+Extensions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public extension Int {
+    var byteCountFromBitCount: Int {
+        Int(floor(Double(self + 7) / Double(8)))
+    }
+}

--- a/Sources/ImmutableXCore/Extensions/String+Extensions.swift
+++ b/Sources/ImmutableXCore/Extensions/String+Extensions.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public extension String {
+    /// Drops "0x" prefix if exists
+    var dropHexPrefix: String {
+        hasPrefix("0x") ? String(dropFirst(2)) : self
+    }
+
+    /// Adds "0x" prefix if doesnt exist
+    var addHexPrefix: String {
+        hasPrefix("0x") ? self : "0x" + self
+    }
+
+    func hexToData() -> Data {
+        Data([UInt8](hex: self))
+    }
+}

--- a/Sources/ImmutableXCore/Utils/Errors.swift
+++ b/Sources/ImmutableXCore/Utils/Errors.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum KeyError: Error {
+    case invalidData
+}

--- a/Tests/ImmutableXCoreTests/Crypto/Keys/KeyPairTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/Keys/KeyPairTests.swift
@@ -1,0 +1,15 @@
+import BigInt
+@testable import ImmutableXCore
+import XCTest
+
+final class KeyPairTests: XCTestCase {
+    func testInitPrivateKey() throws {
+        let privateKey = try PrivateKey(number: StarkCurve.N - 1)
+        let publicKey = try PublicKey(privateKey: privateKey)
+
+        let pair = KeyPair(private: privateKey, public: publicKey)
+
+        XCTAssertEqual(pair.privateKey, privateKey)
+        XCTAssertEqual(pair.publicKey, publicKey)
+    }
+}

--- a/Tests/ImmutableXCoreTests/Crypto/Keys/PrivateKeyTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/Keys/PrivateKeyTests.swift
@@ -1,0 +1,32 @@
+import BigInt
+@testable import ImmutableXCore
+import XCTest
+
+final class PrivateKeyTests: XCTestCase {
+    func testInitNumber() throws {
+        let biggerNumber = StarkCurve.N + 1
+        XCTAssertThrowsError(try PrivateKey(number: biggerNumber), "Should throw if number is not in the StarkCurve.N range") { error in
+            XCTAssertTrue(error is KeyError)
+        }
+
+        XCTAssertThrowsError(try PrivateKey(number: BigInt.zero), "Should throw if number is smaller than 1") { error in
+            XCTAssertTrue(error is KeyError)
+        }
+
+        let inRangeNumber = StarkCurve.N - 1
+        let privateKey = try PrivateKey(number: inRangeNumber)
+        XCTAssertEqual(privateKey.number, inRangeNumber)
+        XCTAssertEqual(privateKey.asData, inRangeNumber.as256bitLongData())
+    }
+
+    func testInitHex() throws {
+        XCTAssertThrowsError(try PrivateKey(hex: "invalid"), "Should throw if hex can't be represented as a BigInt") { error in
+            XCTAssertTrue(error is KeyError)
+        }
+
+        let inRangeNumber = StarkCurve.N - 1
+        let privateKey = try PrivateKey(hex: inRangeNumber.asString(radix: 16))
+        XCTAssertEqual(privateKey.number, inRangeNumber)
+        XCTAssertEqual(privateKey.asData, inRangeNumber.as256bitLongData())
+    }
+}

--- a/Tests/ImmutableXCoreTests/Crypto/Keys/PublicKeyTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/Keys/PublicKeyTests.swift
@@ -1,0 +1,32 @@
+import BigInt
+@testable import ImmutableXCore
+import XCTest
+
+final class PublicKeyTests: XCTestCase {
+    private let privateKeyNumber = StarkCurve.N - 1
+
+    private let expectedEvenCurve = CurvePoint(
+        x: BigInt("874739451078007766457464989774322083649278607533249481151382481072868806602"),
+        y: BigInt("3465835996594612382828747225282121752581686814550857218630150674910346159074")
+    )
+
+    private let oddCurve = CurvePoint(
+        x: BigInt("874739451078007766457464989774322083649278607533249481151382481072868806602"),
+        y: BigInt("3465835996594612382828747225282121752581686814550857218630150674910346159073")
+    )
+
+    func testInitPrivateKey() throws {
+        let privateKey = try PrivateKey(number: privateKeyNumber)
+        let publicKey = try PublicKey(privateKey: privateKey)
+
+        XCTAssertEqual(publicKey.point, expectedEvenCurve)
+        XCTAssertEqual(publicKey.compressedData, Data([0x02]) + expectedEvenCurve.x.as256bitLongData())
+        XCTAssertEqual(publicKey, try PublicKey(privateKey: privateKey))
+    }
+
+    func testInitCurvePoint() throws {
+        let publicKey = try PublicKey(point: oddCurve)
+        XCTAssertEqual(publicKey.point, oddCurve)
+        XCTAssertEqual(publicKey.compressedData, Data([0x03]) + oddCurve.x.as256bitLongData())
+    }
+}

--- a/Tests/ImmutableXCoreTests/Crypto/Stark/StarkCurveTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/Stark/StarkCurveTests.swift
@@ -1,0 +1,83 @@
+import BigInt
+@testable import ImmutableXCore
+import XCTest
+
+final class StarkCurveTests: XCTestCase {
+    func testModN() throws {
+        XCTAssertEqual(StarkCurve.modN(18926), BigInt(18926).modulus(StarkCurve.N))
+    }
+
+    func testModP() throws {
+        XCTAssertEqual(StarkCurve.modP(18926), BigInt(18926).modulus(StarkCurve.P))
+    }
+
+    func testModInverseN() throws {
+        let value1 = BigInt(123_123)
+        let value2 = BigInt(543_543)
+        XCTAssertEqual(StarkCurve.modInverseN(value1, value2), StarkCurve.divide(value1, by: value2, mod: StarkCurve.N))
+    }
+
+    func testModInverseP() throws {
+        let value1 = BigInt(123_123)
+        let value2 = BigInt(543_543)
+        XCTAssertEqual(StarkCurve.modInverseP(value1, value2), StarkCurve.divide(value1, by: value2, mod: StarkCurve.P))
+    }
+
+    func testAdditionReturnsNilWhenXsAreEqualButYsDifferent() throws {
+        let p1 = CurvePoint(x: BigInt(1), y: BigInt(2))
+        let p2 = CurvePoint(x: BigInt(1), y: BigInt(3))
+        XCTAssertNil(StarkCurve.addition(p1, p2))
+    }
+
+    func testAdditionReturnsP2IfP1IsNil() throws {
+        let p2 = CurvePoint(x: BigInt(1), y: BigInt(3))
+        XCTAssertEqual(StarkCurve.addition(nil, p2), p2)
+    }
+
+    func testAdditionReturnsP1IfP2IsNil() throws {
+        let p1 = CurvePoint(x: BigInt(1), y: BigInt(3))
+        XCTAssertEqual(StarkCurve.addition(p1, nil), p1)
+    }
+
+    func testAdditionDoublesPointIfP1AndP2AreEqual() throws {
+        let p1 = CurvePoint(x: BigInt(1), y: BigInt(3))
+        let p2 = CurvePoint(x: BigInt(1), y: BigInt(3))
+        XCTAssertEqual(
+            StarkCurve.addition(p1, p2),
+            CurvePoint(
+                x: BigInt("402055865407347912633035864788341122847011912814621855552565784015096891163"),
+                y: BigInt("2144297948839188867376191278871152655184063535011316562947017514747183419543")
+            )
+        )
+    }
+
+    func testAdditionAddsPointIfP1AndP2AreDifferent() throws {
+        let p1 = CurvePoint(x: BigInt(1), y: BigInt(3))
+        let p2 = CurvePoint(x: BigInt(2), y: BigInt(4))
+        XCTAssertEqual(
+            StarkCurve.addition(p1, p2),
+            CurvePoint(
+                x: BigInt("3618502788666131213697322783095070105623107215331596699973092056135872020479"),
+                y: BigInt.zero
+            )
+        )
+    }
+
+    func testMultiply() throws {
+        let p1 = CurvePoint(x: BigInt(1), y: BigInt(3))
+        XCTAssertEqual(
+            StarkCurve.multiply(p1, by: BigInt(5)),
+            CurvePoint(
+                x: BigInt("2425062519850715417264908027841285451121663001259327672961971078160192455827"),
+                y: BigInt("1911311605951940726530513999887245307038092470678989998898051714701747274728")
+            )
+        )
+    }
+
+    func testMultiplyG() throws {
+        XCTAssertEqual(
+            StarkCurve.multiplyG(by: BigInt(5)),
+            StarkCurve.multiply(StarkCurve.G, by: BigInt(5))
+        )
+    }
+}

--- a/Tests/ImmutableXCoreTests/Extensions/BigInt+ExtensionsTests.swift
+++ b/Tests/ImmutableXCoreTests/Extensions/BigInt+ExtensionsTests.swift
@@ -1,0 +1,37 @@
+import BigInt
+@testable import ImmutableXCore
+import XCTest
+
+final class BigIntExtensionsTests: XCTestCase {
+    func testIsEven() throws {
+        XCTAssertEqual(BigInt(1).isEven, false)
+        XCTAssertEqual(BigInt(2).isEven, true)
+        XCTAssertEqual(BigInt(14234).isEven, true)
+        XCTAssertEqual(BigInt(23423).isEven, false)
+        XCTAssertEqual(BigInt("402055865407347912633035864788341122847011912814621855552565784015096891163").isEven, false)
+    }
+
+    func testHexStringInit() {
+        XCTAssertEqual(BigInt(hexString: "1376eb19ad1b0"), BigInt(342_423_542_354_352))
+        XCTAssertEqual(BigInt(hexString: "0x1376eb19ad1b0"), BigInt(342_423_542_354_352))
+        XCTAssertEqual(
+            BigInt(hexString: "7cefd165c3a374ac3e05170d699bf6549e371522883b447b284a3c16fc04ccc"), BigInt("3531907180084456080948977704976059596947036969275297986324692124860996930764")
+        )
+    }
+
+    func testAsString() {
+        XCTAssertEqual(BigInt(342_423_542_354_352).asString(uppercased: false, radix: 16), "1376eb19ad1b0")
+        XCTAssertEqual(BigInt(342_423_542_354_352).asString(uppercased: true, radix: 16), "1376EB19AD1B0")
+        XCTAssertEqual(BigInt(342_423_542_354_352).asString(radix: 10), "342423542354352")
+        XCTAssertEqual(BigInt(hexString: "7cefd165c3a374ac3e05170d699bf6549e371522883b447b284a3c16fc04ccc")!.asString(radix: 10), "3531907180084456080948977704976059596947036969275297986324692124860996930764")
+    }
+
+    func testAsStringLength64() {
+        XCTAssertEqual(BigInt(342_423_542_354_352).asHexStringLength64(), "0000000000000000000000000000000000000000000000000001376eb19ad1b0")
+        XCTAssertEqual(BigInt(342_423_542_354_352).asHexStringLength64(uppercased: true), "0000000000000000000000000000000000000000000000000001376EB19AD1B0")
+    }
+
+    func testAs256bitLongData() {
+        XCTAssertEqual(BigInt(342_423_542_354_352).as256bitLongData(), "0000000000000000000000000000000000000000000000000001376eb19ad1b0".hexToData())
+    }
+}

--- a/Tests/ImmutableXCoreTests/Extensions/Data+Extensions.swift
+++ b/Tests/ImmutableXCoreTests/Extensions/Data+Extensions.swift
@@ -1,0 +1,14 @@
+import BigInt
+@testable import ImmutableXCore
+import XCTest
+
+final class DataExtensionsTests: XCTestCase {
+    func testAsHexString() {
+        XCTAssertEqual(Data([0x1]).asHexString(), "01")
+        XCTAssertEqual(Data([43, 111]).asHexString(), "2b6f")
+        XCTAssertEqual(BigInt(10).asString(radix: 16).hexToData().asHexString(), "0a")
+        XCTAssertEqual(BigInt(2_342_356_255).asString(radix: 16).hexToData().asHexString(), "8b9d851f")
+        XCTAssertEqual(BigInt(509_347_590_347).asString(radix: 16).hexToData().asHexString(), "76977b70cb")
+        XCTAssertEqual(BigInt(012_345_678_980).asString(radix: 16).hexToData().asHexString(), "2dfdc1c804")
+    }
+}

--- a/Tests/ImmutableXCoreTests/Extensions/Int+Extensions.swift
+++ b/Tests/ImmutableXCoreTests/Extensions/Int+Extensions.swift
@@ -1,0 +1,10 @@
+import BigInt
+@testable import ImmutableXCore
+import XCTest
+
+final class IntExtensionsTests: XCTestCase {
+    func testByteCountFromBitCount() throws {
+        XCTAssertEqual(BigInt(123_123_123).bitWidth.byteCountFromBitCount, 4)
+        XCTAssertEqual(BigInt("402055865407347912633035864788341122847011912814621855552565784015096891163").bitWidth.byteCountFromBitCount, 32)
+    }
+}

--- a/Tests/ImmutableXCoreTests/Extensions/String+ExtensionsTests.swift
+++ b/Tests/ImmutableXCoreTests/Extensions/String+ExtensionsTests.swift
@@ -1,0 +1,21 @@
+import BigInt
+@testable import ImmutableXCore
+import XCTest
+
+final class StringExtensionsTests: XCTestCase {
+    func testDropHexPrefix() throws {
+        XCTAssertEqual("1376eb19ad1b0".dropHexPrefix, "1376eb19ad1b0")
+        XCTAssertEqual("0x1376eb19ad1b0".dropHexPrefix, "1376eb19ad1b0")
+    }
+
+    func testAddHexPrefix() throws {
+        XCTAssertEqual("1376eb19ad1b0".addHexPrefix, "0x1376eb19ad1b0")
+        XCTAssertEqual("0x1376eb19ad1b0".addHexPrefix, "0x1376eb19ad1b0")
+    }
+
+    func testHexToData() throws {
+        XCTAssertEqual("01".hexToData(), Data([0x1]))
+        XCTAssertEqual("2b6f".hexToData(), Data([43, 111]))
+        XCTAssertEqual("0x2b6f".hexToData(), Data([43, 111]))
+    }
+}


### PR DESCRIPTION
The curve points and its required calculations to derive from the StarkCurve has been added.

In order to work with such large numbers the BigInt library has been included as a dependency.

SwiftLint's `identifier_name` rule has been disabled because this package will contain lots of math operations that are written in a short variable names as a standard in the equations.

A private key can be created from a BitInt number or a hex, as long as it's in the range of the StarkCurve's N value.

A public key is derived from the private key by multiplying the StarkCurve G point by the private key number.

A bunch of extensions were added to ease the work with hex and bytes.