### PR TITLE
feat: add support to BIP32 key derivation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,6 @@
 disabled_rules:
   - trailing_comma
+  - line_length
   - identifier_name # Lots of math operations are written with short variable names as a standard
 excluded:
   - .build

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ImmutableXCore.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ImmutableXCore.xcscheme
@@ -86,15 +86,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "ImmutableXCore"
-            BuildableName = "ImmutableXCore"
-            BlueprintName = "ImmutableXCore"
-            ReferencedContainer = "container:">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Package.resolved
+++ b/Package.resolved
@@ -17,6 +17,15 @@
         "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
         "version" : "5.3.0"
       }
+    },
+    {
+      "identity" : "secp256k1.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Boilertalk/secp256k1.swift",
+      "state" : {
+        "revision" : "45e458ec3be46cf0a6eb68bc947f797852dc65d8",
+        "version" : "0.1.6"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,5 @@
 // swift-tools-version: 5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
-// swiftlint:disable line_length
 
 import PackageDescription
 
@@ -17,11 +16,9 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(
-            url: "https://github.com/Flight-School/AnyCodable",
-            from: "0.6.5"
-        ),
+        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.5"),
         .package(url: "https://github.com/attaswift/BigInt", from: "5.3.0"),
+        .package(url: "https://github.com/Boilertalk/secp256k1.swift.git", from: "0.1.6"),
     ],
     targets: [
         .binaryTarget(
@@ -36,7 +33,11 @@ let package = Package(
         ),
         .target(
             name: "ImmutableXCore",
-            dependencies: ["AnyCodable", "BigInt"],
+            dependencies: [
+                .product(name: "BigInt", package: "BigInt"),
+                .product(name: "AnyCodable", package: "AnyCodable"),
+                .product(name: "secp256k1", package: "secp256k1.swift"),
+            ],
             resources: [
                 .copy("version"),
             ],
@@ -44,7 +45,10 @@ let package = Package(
         ),
         .testTarget(
             name: "ImmutableXCoreTests",
-            dependencies: ["ImmutableXCore"]
+            dependencies: [
+                .target(name: "ImmutableXCore"),
+                .product(name: "BigInt", package: "BigInt"),
+            ]
         ),
     ]
 )

--- a/Sources/ImmutableXCore/Crypto/BIP32/BIP32Key.swift
+++ b/Sources/ImmutableXCore/Crypto/BIP32/BIP32Key.swift
@@ -1,0 +1,50 @@
+import BigInt
+import CryptoKit
+import Foundation
+import secp256k1
+
+struct BIP32Key {
+    /// - Parameters
+    ///     - seed: seed data for derivation, e.g. personal signature
+    ///     - path: hashed values in the expected format as per Starkware docs `m/purpose'/layer'/application'/ethAddress1'/ethAddress2'/index`
+    /// - Returns: derived private key hex
+    /// - Throws: ``KeyError.invalidData`` if data is not valid
+    ///
+    /// https://docs.starkware.co/starkex-v4/crypto/key-derivation
+    /// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+    static func derive(seed: Data, path: String) throws -> String {
+        let edge: UInt32 = 0x8000_0000
+        let key = SymmetricKey(data: "Bitcoin seed".data(using: .ascii)!)
+        let output = Data(HMAC<SHA512>.authenticationCode(for: seed, using: key))
+        var derivedChainCode = output[32 ..< 64]
+        var derivedPrivateKey = output[0 ..< 32]
+
+        // drop the 'm' prefix
+        for path in path.split(separator: "/").dropFirst() {
+            let hardened = path.hasSuffix("'")
+            let sanitizedPath = path.replacingOccurrences(of: "'", with: "")
+
+            guard let index = UInt32(sanitizedPath), edge & index == 0 else { throw KeyError.invalidData }
+
+            var data = Data()
+
+            if hardened {
+                data += UInt8(0).data
+                data += derivedPrivateKey
+            } else {
+                data += Secp256k1Encrypter.createPublicKey(privateKey: derivedPrivateKey)
+            }
+
+            let derivingIndex = CFSwapInt32BigToHost(hardened ? (edge | index) : index)
+            data += derivingIndex.data
+
+            let digest = Data(HMAC<SHA512>.authenticationCode(for: data, using: SymmetricKey(data: derivedChainCode)))
+            let factor = BigInt(data: digest[0 ..< 32])
+
+            derivedPrivateKey = (BigInt(data: derivedPrivateKey) + factor).modulus(Constants.secpOrder).as256bitLongData()
+            derivedChainCode = digest[32 ..< 64]
+        }
+
+        return derivedPrivateKey.asHexString()
+    }
+}

--- a/Sources/ImmutableXCore/Crypto/Secp256k1/Secp256k1Encrypter.swift
+++ b/Sources/ImmutableXCore/Crypto/Secp256k1/Secp256k1Encrypter.swift
@@ -1,0 +1,29 @@
+import Foundation
+import secp256k1
+
+/// A simple wrapper of ``secp256k1`` lib for creating public keys.
+struct Secp256k1Encrypter {
+    /// Recovers public key from the PrivateKey and converts it to bytes
+    ///
+    /// - Parameters:
+    ///   - privateKey: private key bytes
+    ///   - compressed: whether public key should be compressed.
+    /// - Returns: If compression enabled, public key is 33 bytes size, otherwise it is 65 bytes.
+    static func createPublicKey(privateKey: Data, compressed: Bool = true) -> Data {
+        let context: OpaquePointer = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY))!
+        defer { secp256k1_context_destroy(context) }
+
+        let privateKey: [UInt8] = Array(privateKey)
+        var publicKey = secp256k1_pubkey()
+        _ = secp256k1_ec_pubkey_create(context, &publicKey, privateKey)
+
+        var output = Data(count: compressed ? 33 : 65)
+        var outputLen: Int = output.count
+        let compressedFlags = compressed ? UInt32(SECP256K1_EC_COMPRESSED) : UInt32(SECP256K1_EC_UNCOMPRESSED)
+        output.withUnsafeMutableBytes { pointer in
+            guard let p = pointer.bindMemory(to: UInt8.self).baseAddress else { return }
+            secp256k1_ec_pubkey_serialize(context, p, &outputLen, &publicKey, compressedFlags)
+        }
+        return output
+    }
+}

--- a/Sources/ImmutableXCore/Extensions/BigInt+Extensions.swift
+++ b/Sources/ImmutableXCore/Extensions/BigInt+Extensions.swift
@@ -10,6 +10,10 @@ public extension BigInt {
         self.init(hexString.dropHexPrefix, radix: 16)
     }
 
+    init(sign: BigInt.Sign = .plus, data: Data) {
+        self.init(sign: sign, magnitude: BigInt.Magnitude(data))
+    }
+
     func asString(uppercased: Bool = false, radix: Int) -> String {
         let stringRepresentation = String(self, radix: radix)
         return uppercased ? stringRepresentation.uppercased() : stringRepresentation

--- a/Sources/ImmutableXCore/Extensions/Data+Extensions.swift
+++ b/Sources/ImmutableXCore/Extensions/Data+Extensions.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 public extension Data {
+    init(hex: String) {
+        self.init([UInt8](hex: hex))
+    }
+
     func asHexString() -> String {
         lazy.reduce(into: "") {
             var s = String($1, radix: 16)

--- a/Sources/ImmutableXCore/Extensions/Int+Extensions.swift
+++ b/Sources/ImmutableXCore/Extensions/Int+Extensions.swift
@@ -5,3 +5,17 @@ public extension Int {
         Int(floor(Double(self + 7) / Double(8)))
     }
 }
+
+extension UInt8 {
+    var data: Data {
+        var int = self
+        return Data(bytes: &int, count: MemoryLayout<UInt8>.size)
+    }
+}
+
+extension UInt32 {
+    var data: Data {
+        var int = self
+        return Data(bytes: &int, count: MemoryLayout<UInt32>.size)
+    }
+}

--- a/Sources/ImmutableXCore/Utils/Constants.swift
+++ b/Sources/ImmutableXCore/Utils/Constants.swift
@@ -1,0 +1,6 @@
+import BigInt
+import Foundation
+
+struct Constants {
+    static let secpOrder = BigInt("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", radix: 16)!
+}

--- a/Tests/ImmutableXCoreTests/Crypto/BIP32/BIP32KeyTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/BIP32/BIP32KeyTests.swift
@@ -1,0 +1,22 @@
+import BigInt
+@testable import ImmutableXCore
+import XCTest
+
+final class BIP32KeyTests: XCTestCase {
+    let seed = Data(hex: "4c4a250231bcac7beb165aec4c9b049b4ba40ad8dd287dc79b92b1ffcf20cdcf")
+
+    func testDeriveThrowsForInvalidPath() throws {
+        let path = "m/purpose'/layer'/application'/ethAddress1'/ethAddress2'/1"
+        XCTAssertThrowsError(try BIP32Key.derive(seed: seed, path: path), "unhashed/formatted path") { error in
+            XCTAssertTrue(error is KeyError)
+        }
+    }
+
+    func testDerive() throws {
+        let path = "m/2645'/579218131'/211006541'/1534045311'/1431804530'/1"
+        XCTAssertEqual(
+            try BIP32Key.derive(seed: seed, path: path),
+            "57384e99059bb1c0e51d70f0fca22d18d7191398dd39d6b9b4e0521174b2377a"
+        )
+    }
+}


### PR DESCRIPTION
secp256k1 has been added as a dependency since it's required in the derivation algorithm.