### PR TITLE
fix(buy-workflow): only allow to buy active orders

### DIFF
--- a/Sources/ImmutableXCore/Workflows/BuyWorkflow.swift
+++ b/Sources/ImmutableXCore/Workflows/BuyWorkflow.swift
@@ -41,7 +41,7 @@ class BuyWorkflow {
 
     private static func getSignableTrade(order: Order, address: String, fees: [FeeEntry], api: TradesAPI.Type) async throws -> GetSignableTradeResponse {
         guard order.user != address else { throw WorkflowError.invalidRequest(reason: "Cannot purchase own order") }
-        guard order.status != OrderStatus.active.rawValue else { throw WorkflowError.invalidRequest(reason: "Order not available for purchase") }
+        guard order.status == OrderStatus.active.rawValue else { throw WorkflowError.invalidRequest(reason: "Order not available for purchase") }
         return try await Workflow.mapAPIErrors(caller: "Signable trade") {
             try await api.getSignableTrade(
                 getSignableTradeRequest: GetSignableTradeRequest(

--- a/Tests/ImmutableXCoreTests/Workflows/BuyWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/BuyWorkflowTests.swift
@@ -12,7 +12,7 @@ final class BuyWorkflowTests: XCTestCase {
         tradesAPI.resetMock()
 
         let orderCompanion = OrdersAPIMockGetCompanion()
-        orderCompanion.getOrderReturnValue = orderFilledStub1
+        orderCompanion.getOrderReturnValue = orderActiveStub2
         ordersAPI.mock(orderCompanion, id: "1")
 
         let tradeGetCompanion = TradesAPIMockGetCompanion()
@@ -71,7 +71,7 @@ final class BuyWorkflowTests: XCTestCase {
 
     func testBuyFlowThrowsWhenPurchaseOwnOrder() async throws {
         let signer = SignerMock()
-        signer.getAddressReturnValue = orderFilledStub1.user
+        signer.getAddressReturnValue = orderActiveStub2.user
 
         do {
             _ = try await BuyWorkflow.buy(
@@ -88,9 +88,9 @@ final class BuyWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyFlowThrowsWhenOrderStatusIsActive() async throws {
+    func testBuyFlowThrowsWhenOrderStatusIsNotActive() async throws {
         let orderCompanion = OrdersAPIMockGetCompanion()
-        orderCompanion.getOrderReturnValue = orderActiveStub2
+        orderCompanion.getOrderReturnValue = orderFilledStub1
         ordersAPI.mock(orderCompanion, id: "1")
 
         do {


### PR DESCRIPTION
The logic ended up being inverted due to a misunderstanding of the
requirements. An order can only be bought when its status is active.