### PR TITLE
refactor: remove unnecessary methods from Signer

### DIFF
--- a/Sources/ImmutableXCore/Signer.swift
+++ b/Sources/ImmutableXCore/Signer.swift
@@ -7,11 +7,6 @@ public protocol Signer {
     /// - Returns: the account address.
     func getAddress() async throws -> String
 
-    /// This method relies on a closure so that a ``Signer`` can be designed around an asynchronous source,
-    /// such as hardware wallets.
-    /// - Returns: the account address as part of the `onCompletion` argument.
-    func getAddress(onCompletion: @escaping (Result<String, Error>) -> Void)
-
     /// A signed message is prefixed with "\x19Ethereum Signed Message:\n" and the length of the
     /// message, using the hashMessage method, so that it is EIP-191 compliant. If recovering the
     /// address in Solidity, this prefix will be required to create a matching hash.
@@ -21,17 +16,6 @@ public protocol Signer {
     ///
     /// - Returns: signature
     func signMessage(_ message: String) async throws -> String
-
-    /// A signed message is prefixed with "\x19Ethereum Signed Message:\n" and the length of the
-    /// message, using the hashMessage method, so that it is EIP-191 compliant. If recovering the
-    /// address in Solidity, this prefix will be required to create a matching hash.
-    ///
-    /// Sub-classes must implement this, however they may return an error as part of the `onCompletion`
-    /// argument if signing a message is not supported, such as in a Contract-based Wallet or
-    /// Meta-Transaction-based Wallet.
-    ///
-    /// - Returns: signature as part of the `onCompletion` argument.
-    func signMessage(_ message: String, onCompletion: @escaping (Result<String, Error>) -> Void)
 }
 
 /// This represents the Immutable X Wallet on Layer 2 and will have reference to the user's Stark key pair for signing L2 transactions.
@@ -41,11 +25,6 @@ public protocol StarkSigner {
     /// - Returns: the account address.
     func getAddress() async throws -> String
 
-    /// This method relies on a closure so that a ``Signer`` can be designed around an asynchronous source,
-    /// such as hardware wallets.
-    /// - Returns: the account address as part of the `onCompletion` argument.
-    func getAddress(onCompletion: @escaping (Result<String, Error>) -> Void)
-
     /// Signs the `message` with the user's L2 Stark keys.
     ///
     /// When implementing this, make sure `message` is in hex format and pass it and the L2 Stark key pair to the
@@ -53,12 +32,4 @@ public protocol StarkSigner {
     ///
     /// - Returns: serialized Stark signature
     func signMessage(_ message: String) async throws -> String
-
-    /// Signs the `message` with the user's L2 Stark keys.
-    ///
-    /// When implementing this, make sure `message` is in hex format and pass it and the L2 Stark key pair to the
-    /// ``StarkKey/sign(message:with:)`` function.
-    ///
-    /// - Returns: serialized Stark signature as part of the `onCompletion` argument.
-    func signMessage(_ message: String, onCompletion: @escaping (Result<String, Error>) -> Void)
 }

--- a/Tests/ImmutableXCoreTests/Mocks/SignerMock.swift
+++ b/Tests/ImmutableXCoreTests/Mocks/SignerMock.swift
@@ -21,24 +21,6 @@ final class SignerMock: Signer {
         return try getAddressClosure.map { try $0() } ?? getAddressReturnValue
     }
 
-    // MARK: - getAddress
-
-    var getAddressOnCompletionCallsCount = 0
-    var getAddressOnCompletionCalled: Bool {
-        getAddressOnCompletionCallsCount > 0
-    }
-
-    var getAddressOnCompletionReceivedOnCompletion: ((Result<String, Error>) -> Void)?
-    var getAddressOnCompletionReceivedInvocations: [(Result<String, Error>) -> Void] = []
-    var getAddressOnCompletionClosure: ((@escaping (Result<String, Error>) -> Void) -> Void)?
-
-    func getAddress(onCompletion: @escaping (Result<String, Error>) -> Void) {
-        getAddressOnCompletionCallsCount += 1
-        getAddressOnCompletionReceivedOnCompletion = onCompletion
-        getAddressOnCompletionReceivedInvocations.append(onCompletion)
-        getAddressOnCompletionClosure?(onCompletion)
-    }
-
     // MARK: - signMessage
 
     var signMessageThrowableError: Error?
@@ -60,23 +42,5 @@ final class SignerMock: Signer {
         signMessageReceivedMessage = message
         signMessageReceivedInvocations.append(message)
         return try signMessageClosure.map { try $0(message) } ?? signMessageReturnValue
-    }
-
-    // MARK: - signMessage
-
-    var signMessageOnCompletionCallsCount = 0
-    var signMessageOnCompletionCalled: Bool {
-        signMessageOnCompletionCallsCount > 0
-    }
-
-    var signMessageOnCompletionReceivedArguments: (message: String, onCompletion: (Result<String, Error>) -> Void)?
-    var signMessageOnCompletionReceivedInvocations: [(message: String, onCompletion: (Result<String, Error>) -> Void)] = []
-    var signMessageOnCompletionClosure: ((String, @escaping (Result<String, Error>) -> Void) -> Void)?
-
-    func signMessage(_ message: String, onCompletion: @escaping (Result<String, Error>) -> Void) {
-        signMessageOnCompletionCallsCount += 1
-        signMessageOnCompletionReceivedArguments = (message: message, onCompletion: onCompletion)
-        signMessageOnCompletionReceivedInvocations.append((message: message, onCompletion: onCompletion))
-        signMessageOnCompletionClosure?(message, onCompletion)
     }
 }

--- a/Tests/ImmutableXCoreTests/Mocks/StarkSignerMock.swift
+++ b/Tests/ImmutableXCoreTests/Mocks/StarkSignerMock.swift
@@ -21,24 +21,6 @@ final class StarkSignerMock: StarkSigner {
         return try getAddressClosure.map { try $0() } ?? getAddressReturnValue
     }
 
-    // MARK: - getAddress
-
-    var getAddressOnCompletionCallsCount = 0
-    var getAddressOnCompletionCalled: Bool {
-        getAddressOnCompletionCallsCount > 0
-    }
-
-    var getAddressOnCompletionReceivedOnCompletion: ((Result<String, Error>) -> Void)?
-    var getAddressOnCompletionReceivedInvocations: [(Result<String, Error>) -> Void] = []
-    var getAddressOnCompletionClosure: ((@escaping (Result<String, Error>) -> Void) -> Void)?
-
-    func getAddress(onCompletion: @escaping (Result<String, Error>) -> Void) {
-        getAddressOnCompletionCallsCount += 1
-        getAddressOnCompletionReceivedOnCompletion = onCompletion
-        getAddressOnCompletionReceivedInvocations.append(onCompletion)
-        getAddressOnCompletionClosure?(onCompletion)
-    }
-
     // MARK: - signMessage
 
     var signMessageThrowableError: Error?
@@ -60,23 +42,5 @@ final class StarkSignerMock: StarkSigner {
         signMessageReceivedMessage = message
         signMessageReceivedInvocations.append(message)
         return try signMessageClosure.map { try $0(message) } ?? signMessageReturnValue
-    }
-
-    // MARK: - signMessage
-
-    var signMessageOnCompletionCallsCount = 0
-    var signMessageOnCompletionCalled: Bool {
-        signMessageOnCompletionCallsCount > 0
-    }
-
-    var signMessageOnCompletionReceivedArguments: (message: String, onCompletion: (Result<String, Error>) -> Void)?
-    var signMessageOnCompletionReceivedInvocations: [(message: String, onCompletion: (Result<String, Error>) -> Void)] = []
-    var signMessageOnCompletionClosure: ((String, @escaping (Result<String, Error>) -> Void) -> Void)?
-
-    func signMessage(_ message: String, onCompletion: @escaping (Result<String, Error>) -> Void) {
-        signMessageOnCompletionCallsCount += 1
-        signMessageOnCompletionReceivedArguments = (message: message, onCompletion: onCompletion)
-        signMessageOnCompletionReceivedInvocations.append((message: message, onCompletion: onCompletion))
-        signMessageOnCompletionClosure?(message, onCompletion)
     }
 }


### PR DESCRIPTION
It didnt make sense to have multiple ways of retrieving the same data
since ultimately the SDK only uses the async/await approach. We'd have
to reimplement everything in the old closure style to make use of it,
which is not worth the maintenance. It is very simple for developers
to wrap closure based callbacks in async/await for this particular
scenario.

All other implementations the SDK exposes will continue to support the
old closure style.