### PR TITLE
refactor(tests): add async throws assert helper

### DIFF
--- a/Tests/ImmutableXCoreTests/Custom APIs/ExchangesAPITests.swift
+++ b/Tests/ImmutableXCoreTests/Custom APIs/ExchangesAPITests.swift
@@ -17,14 +17,11 @@ final class ExchangesAPITests: XCTestCase {
         XCTAssertEqual(response.id, 123)
     }
 
-    func testGetTransactionIdFailure() async throws {
+    func testGetTransactionIdFailure() {
         builderMock.mock(Result<Response<GetSignedMoonpayResponse>, ErrorResponse>.failure(.error(400, nil, nil, DummyError.something)))
 
-        do {
-            _ = try await exchangesAPI.getTransactionId(GetTransactionIdRequest(walletAddress: "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f", provider: .moonpay))
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is ErrorResponse)
+        XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await self.exchangesAPI.getTransactionId(GetTransactionIdRequest(walletAddress: "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f", provider: .moonpay))
         }
     }
 
@@ -36,14 +33,11 @@ final class ExchangesAPITests: XCTestCase {
         XCTAssertEqual(response.currencyCodes, ["code": "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f"])
     }
 
-    func testGetCurrenciesFailure() async throws {
+    func testGetCurrenciesFailure() {
         builderMock.mock(Result<Response<[CurrencyCode]>, ErrorResponse>.failure(.error(400, nil, nil, DummyError.something)))
 
-        do {
-            _ = try await exchangesAPI.getCurrencies(address: "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f")
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is ErrorResponse)
+        XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await self.exchangesAPI.getCurrencies(address: "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f")
         }
     }
 }

--- a/Tests/ImmutableXCoreTests/Custom APIs/MoonpayAPITests.swift
+++ b/Tests/ImmutableXCoreTests/Custom APIs/MoonpayAPITests.swift
@@ -30,14 +30,11 @@ final class MoonpayAPITests: XCTestCase {
         XCTAssertEqual(url, "https://buy-staging.moonpay.io/?apiKey=pk_test_nGdsu1IBkjiFzmEvN8ddf4gM9GNy5Sgz&baseCurrencyCode=usd&colorCode=%23#008000&externalTransactionId=123&walletAddress=0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f&walletAddresses=%7B%22gods_immutable%22%3A%220xa76e3eeb2f7143165618ab8feaabcd395b6fac7f%22%7D&signature=signature")
     }
 
-    func testGetBuyCryptoURLFailure() async throws {
+    func testGetBuyCryptoURLFailure() {
         builderMock.mock(Result<Response<GetSignedMoonpayResponse>, ErrorResponse>.failure(.error(400, nil, nil, DummyError.something)))
 
-        do {
-            _ = try await moonpayAPI.getBuyCryptoURL(request)
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is ErrorResponse)
+        XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await self.moonpayAPI.getBuyCryptoURL(request)
         }
     }
 }

--- a/Tests/ImmutableXCoreTests/ImmutableXCoreTests.swift
+++ b/Tests/ImmutableXCoreTests/ImmutableXCoreTests.swift
@@ -62,16 +62,13 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(response, createTradeResponseStub1)
     }
 
-    func testBuyFlowFailureAsync() async throws {
+    func testBuyFlowFailureAsync() {
         let buyCompanion = BuyWorkflowCompanion()
         buyCompanion.throwableError = DummyError.something
         buyWorkflow.mock(buyCompanion, id: "1")
 
-        do {
-            _ = try await core.buy(orderId: "1", fees: [feeEntryStub1], signer: SignerMock(), starkSigner: StarkSignerMock())
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is DummyError)
+        XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await self.core.buy(orderId: "1", fees: [feeEntryStub1], signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
 
@@ -117,16 +114,13 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(response, createOrderResponseStub1)
     }
 
-    func testSellFlowFailureAsync() async throws {
+    func testSellFlowFailureAsync() {
         let sellCompanion = SellWorkflowCompanion()
         sellCompanion.throwableError = DummyError.something
         sellWorkflow.mock(sellCompanion)
 
-        do {
-            _ = try await core.sell(asset: erc721AssetStub1, sellToken: erc20AssetStub1, fees: [], signer: SignerMock(), starkSigner: StarkSignerMock())
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is DummyError)
+        XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await self.core.sell(asset: erc721AssetStub1, sellToken: erc20AssetStub1, fees: [], signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
 
@@ -172,16 +166,13 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(response, cancelOrderResponseStub1)
     }
 
-    func testCancelOrderFlowFailureAsync() async throws {
+    func testCancelOrderFlowFailureAsync() {
         let cancelOrderCompanion = CancelOrderWorkflowCompanion()
         cancelOrderCompanion.throwableError = DummyError.something
         cancelOrderWorkflow.mock(cancelOrderCompanion, id: "1")
 
-        do {
-            _ = try await core.cancelOrder(orderId: "1", signer: SignerMock(), starkSigner: StarkSignerMock())
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is DummyError)
+        XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await self.core.cancelOrder(orderId: "1", signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
 
@@ -227,16 +218,13 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(response, createTransferResponseStub1)
     }
 
-    func testTransferFlowFailureAsync() async throws {
+    func testTransferFlowFailureAsync() {
         let transferCompanion = TransferWorkflowCompanion()
         transferCompanion.throwableError = DummyError.something
         transferWorkflowMock.mock(transferCompanion)
 
-        do {
-            _ = try await core.transfer(token: ETHAsset(quantity: "10"), recipientAddress: "address", signer: SignerMock(), starkSigner: StarkSignerMock())
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is DummyError)
+        XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await self.core.transfer(token: ETHAsset(quantity: "10"), recipientAddress: "address", signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
 
@@ -283,16 +271,13 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(registerWorkflowMock.companion.callsCount, 1)
     }
 
-    func testRegisterFlowFailureAsync() async throws {
+    func testRegisterFlowFailureAsync() {
         let registerCompanion = RegisterWorkflowCompanion()
         registerCompanion.throwableError = DummyError.something
         registerWorkflowMock.mock(registerCompanion)
 
-        do {
-            _ = try await core.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock())
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is DummyError)
+        XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await self.core.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
 

--- a/Tests/ImmutableXCoreTests/Workflows/BuyWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/BuyWorkflowTests.swift
@@ -37,134 +37,113 @@ final class BuyWorkflowTests: XCTestCase {
         XCTAssertEqual(response, createTradeResponseStub1)
     }
 
-    func testBuyFlowThrowsWhenFeePercentageIsInvalid() async throws {
-        do {
+    func testBuyFlowThrowsWhenFeePercentageIsInvalid() {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [FeeEntry(address: "address", feePercentage: nil)],
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI,
-                tradesAPI: tradesAPI
+                ordersAPI: self.ordersAPI,
+                tradesAPI: self.tradesAPI
             )
-            XCTFail("Should have thrown")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
         }
     }
 
-    func testBuyFlowThrowsWhenFeeAddressIsInvalid() async throws {
-        do {
+    func testBuyFlowThrowsWhenFeeAddressIsInvalid() {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [FeeEntry(address: nil, feePercentage: 2)],
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI,
-                tradesAPI: tradesAPI
+                ordersAPI: self.ordersAPI,
+                tradesAPI: self.tradesAPI
             )
-            XCTFail("Should have thrown")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
         }
     }
 
-    func testBuyFlowThrowsWhenPurchaseOwnOrder() async throws {
+    func testBuyFlowThrowsWhenPurchaseOwnOrder() {
         let signer = SignerMock()
         signer.getAddressReturnValue = orderActiveStub2.user
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],
                 signer: signer,
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI,
-                tradesAPI: tradesAPI
+                ordersAPI: self.ordersAPI,
+                tradesAPI: self.tradesAPI
             )
-            XCTFail("Should have thrown")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
         }
     }
 
-    func testBuyFlowThrowsWhenOrderStatusIsNotActive() async throws {
+    func testBuyFlowThrowsWhenOrderStatusIsNotActive() {
         let orderCompanion = OrdersAPIMockGetCompanion()
         orderCompanion.returnValue = orderFilledStub1
         ordersAPI.mock(orderCompanion, id: "1")
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI,
-                tradesAPI: tradesAPI
+                ordersAPI: self.ordersAPI,
+                tradesAPI: self.tradesAPI
             )
-            XCTFail("Should have thrown")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
         }
     }
 
-    func testBuyFlowThrowsWhenGetOrderFails() async throws {
+    func testBuyFlowThrowsWhenGetOrderFails() {
         let orderCompanion = OrdersAPIMockGetCompanion()
         orderCompanion.throwableError = DummyError.something
         ordersAPI.mock(orderCompanion, id: "1")
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI,
-                tradesAPI: tradesAPI
+                ordersAPI: self.ordersAPI,
+                tradesAPI: self.tradesAPI
             )
-            XCTFail("Should have thrown")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
         }
     }
 
-    func testBuyFlowThrowsWhenGetSignableTradeFails() async throws {
+    func testBuyFlowThrowsWhenGetSignableTradeFails() {
         let tradeGetCompanion = TradesAPIMockGetCompanion()
         tradeGetCompanion.throwableError = DummyError.something
         tradesAPI.mock(tradeGetCompanion, id: 1)
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI,
-                tradesAPI: tradesAPI
+                ordersAPI: self.ordersAPI,
+                tradesAPI: self.tradesAPI
             )
-            XCTFail("Should have thrown")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
         }
     }
 
-    func testBuyFlowThrowsWhenCreateSignableTradeFails() async throws {
+    func testBuyFlowThrowsWhenCreateSignableTradeFails() {
         let tradeCreateCompanion = TradesAPIMockCreateCompanion()
         tradeCreateCompanion.throwableError = DummyError.something
         tradesAPI.mock(tradeCreateCompanion, id: 1)
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI,
-                tradesAPI: tradesAPI
+                ordersAPI: self.ordersAPI,
+                tradesAPI: self.tradesAPI
             )
-            XCTFail("Should have thrown")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
         }
     }
 }

--- a/Tests/ImmutableXCoreTests/Workflows/CancelOrderWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/CancelOrderWorkflowTests.swift
@@ -29,41 +29,33 @@ final class CancelOrderWorkflowTests: XCTestCase {
         XCTAssertEqual(response, cancelOrderResponseStub1)
     }
 
-    func testCancelFlowThrowsWhenGetSignableCancelOrderFails() async throws {
+    func testCancelFlowThrowsWhenGetSignableCancelOrderFails() {
         let signableCompanion = OrdersAPIMockGetSignableCancelCompanion()
         signableCompanion.throwableError = DummyError.something
         ordersAPI.mock(signableCompanion)
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await CancelOrderWorkflow.cancel(
                 orderId: "1",
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI
+                ordersAPI: self.ordersAPI
             )
-
-            XCTFail("Should have not succeeded")
-        } catch {
-            XCTAssertTrue(error is WorkflowError, "non-Immutable X errors gets mapped to WorkflowError")
         }
     }
 
-    func testCancelFlowThrowsWhenCancelOrderFails() async throws {
+    func testCancelFlowThrowsWhenCancelOrderFails() {
         let cancelOrderCompanion = OrdersAPIMockCancelOrderCompanion()
         cancelOrderCompanion.throwableError = DummyError.something
         ordersAPI.mock(cancelOrderCompanion)
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await CancelOrderWorkflow.cancel(
                 orderId: "1",
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI
+                ordersAPI: self.ordersAPI
             )
-
-            XCTFail("Should have not succeeded")
-        } catch {
-            XCTAssertTrue(error is WorkflowError, "non-Immutable X errors gets mapped to WorkflowError")
         }
     }
 }

--- a/Tests/ImmutableXCoreTests/Workflows/RegisterWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/RegisterWorkflowTests.swift
@@ -46,51 +46,48 @@ final class RegisterWorkflowTests: XCTestCase {
         XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
     }
 
-    func testRegistrationThrowsIfGetUsersResponseFails() async throws {
+    func testRegistrationThrowsIfGetUsersResponseFails() {
         let usersCompanion = UsersAPIMockGetUsersCompanion()
         usersCompanion.throwableError = ErrorResponse.error(400, nil, nil, DummyError.something)
         usersAPI.mock(usersCompanion)
 
-        do {
-            _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: usersAPI)
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
-            XCTAssertEqual(usersAPI.getUsersCompanion?.callsCount, 1)
-            XCTAssertEqual(usersAPI.getSignableCompanion?.callsCount, 0)
-            XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
+        let error = XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: self.usersAPI)
         }
+
+        XCTAssertTrue(error is WorkflowError)
+        XCTAssertEqual(usersAPI.getUsersCompanion?.callsCount, 1)
+        XCTAssertEqual(usersAPI.getSignableCompanion?.callsCount, 0)
+        XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
     }
 
-    func testRegistrationThrowsIfSignableResponseFails() async throws {
+    func testRegistrationThrowsIfSignableResponseFails() {
         let signableCompanion = UsersAPIMockGetSignableCompanion()
         signableCompanion.throwableError = DummyError.something
         usersAPI.mock(signableCompanion)
 
-        do {
-            _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: usersAPI)
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
-            XCTAssertEqual(usersAPI.getUsersCompanion?.callsCount, 1)
-            XCTAssertEqual(usersAPI.getSignableCompanion?.callsCount, 1)
-            XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
+        let error = XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: self.usersAPI)
         }
+
+        XCTAssertTrue(error is WorkflowError)
+        XCTAssertEqual(usersAPI.getUsersCompanion?.callsCount, 1)
+        XCTAssertEqual(usersAPI.getSignableCompanion?.callsCount, 1)
+        XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
     }
 
-    func testRegistrationThrowsIfRegisterResponseFails() async throws {
+    func testRegistrationThrowsIfRegisterResponseFails() {
         let registerCompanion = UsersAPIMockRegisterCompanion()
         registerCompanion.throwableError = DummyError.something
         usersAPI.mock(registerCompanion)
 
-        do {
-            _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: usersAPI)
-            XCTFail("Should have failed")
-        } catch {
-            XCTAssertTrue(error is WorkflowError)
-            XCTAssertEqual(usersAPI.getUsersCompanion?.callsCount, 1)
-            XCTAssertEqual(usersAPI.getSignableCompanion?.callsCount, 1)
-            XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 1)
+        let error = XCTAssertThrowsErrorAsync { [unowned self] in
+            _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: self.usersAPI)
         }
+
+        XCTAssertTrue(error is WorkflowError)
+        XCTAssertEqual(usersAPI.getUsersCompanion?.callsCount, 1)
+        XCTAssertEqual(usersAPI.getSignableCompanion?.callsCount, 1)
+        XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 1)
     }
 }

--- a/Tests/ImmutableXCoreTests/Workflows/SellWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/SellWorkflowTests.swift
@@ -31,45 +31,37 @@ final class SellWorkflowTests: XCTestCase {
         XCTAssertEqual(response, createOrderResponseStub1)
     }
 
-    func testSellFlowFailureWhenSignableOrderThrows() async throws {
+    func testSellFlowFailureWhenSignableOrderThrows() {
         let signableCompanion = OrdersAPIMockGetSignableCompanion()
         signableCompanion.throwableError = DummyError.something
         ordersAPI.mock(signableCompanion)
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await SellWorkflow.sell(
                 asset: erc721AssetStub1,
                 sellToken: erc20AssetStub1,
                 fees: [],
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI
+                ordersAPI: self.ordersAPI
             )
-
-            XCTFail("Should have not succeeded")
-        } catch {
-            XCTAssertTrue(error is WorkflowError, "non-Immutable X errors gets mapped to WorkflowError")
         }
     }
 
-    func testSellFlowFailureWhenCreateOrderThrows() async throws {
+    func testSellFlowFailureWhenCreateOrderThrows() {
         let createOrderCompanion = OrdersAPIMockCreateOrderCompanion()
         createOrderCompanion.throwableError = DummyError.something
         ordersAPI.mock(createOrderCompanion)
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await SellWorkflow.sell(
                 asset: erc721AssetStub1,
                 sellToken: erc20AssetStub1,
                 fees: [],
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                ordersAPI: ordersAPI
+                ordersAPI: self.ordersAPI
             )
-
-            XCTFail("Should have not succeeded")
-        } catch {
-            XCTAssertTrue(error is WorkflowError, "non-Immutable X errors gets mapped to WorkflowError")
         }
     }
 }

--- a/Tests/ImmutableXCoreTests/Workflows/TransferWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/TransferWorkflowTests.swift
@@ -57,43 +57,35 @@ final class TransferWorkflowTests: XCTestCase {
         XCTAssertEqual(response, createTransferResponseStub1)
     }
 
-    func testTransferFlowFailsOnSignableTransferError() async throws {
+    func testTransferFlowFailsOnSignableTransferError() {
         let signableCompanion = TransfersAPIMockGetSignableCompanion()
         signableCompanion.throwableError = DummyError.something
         transfersAPI.mock(signableCompanion)
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await TransferWorkflow.transfer(
                 token: erc721Token,
                 recipientAddress: recipientAddress,
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                transfersAPI: transfersAPI
+                transfersAPI: self.transfersAPI
             )
-
-            XCTFail("Should have not succeeded")
-        } catch {
-            XCTAssertTrue(error is WorkflowError, "non-Immutable X errors gets mapped to WorkflowError")
         }
     }
 
-    func testTransferFlowFailsOnInvalidSignableResponse() async throws {
+    func testTransferFlowFailsOnInvalidSignableResponse() {
         let signableCompanion = TransfersAPIMockGetSignableCompanion()
         signableCompanion.returnValue = signableTransferResponseStub2
         transfersAPI.mock(signableCompanion)
 
-        do {
+        XCTAssertThrowsErrorAsync { [unowned self] in
             _ = try await TransferWorkflow.transfer(
                 token: erc721Token,
                 recipientAddress: recipientAddress,
                 signer: SignerMock(),
                 starkSigner: StarkSignerMock(),
-                transfersAPI: transfersAPI
+                transfersAPI: self.transfersAPI
             )
-
-            XCTFail("Should have not succeeded")
-        } catch {
-            XCTAssertTrue(error is WorkflowError, "non-Immutable X errors gets mapped to WorkflowError")
         }
     }
 }

--- a/Tests/ImmutableXCoreTests/XCTestCase+Extensions.swift
+++ b/Tests/ImmutableXCoreTests/XCTestCase+Extensions.swift
@@ -1,0 +1,30 @@
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    /// Expects that the async code will throw
+    @discardableResult
+    func XCTAssertThrowsErrorAsync(testName: String = #function, file: StaticString = #filePath, line: UInt = #line, timeout: TimeInterval = 20, test: @escaping () async throws -> Void) -> Error? {
+        var thrownError: Error?
+        let errorHandler = { thrownError = $0 }
+        let expectation = expectation(description: testName)
+
+        Task {
+            do {
+                try await test()
+            } catch {
+                errorHandler(error)
+            }
+
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: timeout), .completed, file: file, line: line)
+
+        if thrownError == nil {
+            XCTFail("\(testName) should have failed", file: file, line: line)
+        }
+
+        return thrownError
+    }
+}


### PR DESCRIPTION
Replaces the more verbose do catch statement for asserting that certain methods throw. The idea is to mimic the native `XCTAssertThrowsError()` assert function, which does not work with async code.