### PR TITLE
ci: fix publish cocoapods workflow name

### DIFF
--- a/.github/workflows/publish_cocoapods.yml
+++ b/.github/workflows/publish_cocoapods.yml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 jobs:
-  unit_tests:
+  publish_cocoapods:
     runs-on: macos-12
     steps:
     - name: Repository checkout
@@ -14,7 +14,7 @@ jobs:
     - name: Deploy to Cocoapods
       run: |
         set -eo pipefail
-        pod lib lint --allow-warnings
-        pod trunk push --allow-warnings
+        pod lib lint --allow-warnings --verbose
+        pod trunk push --allow-warnings --verbose
       env:
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
The name was accidentally set as unit_tests, instead of publish_cocoapods as it should have.

Also make commands be verbose to enable debugging.