### PR TITLE
feat: make keys models Codable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ for added features.
 
 ### Changed
 
-for changed features.
+- Make PrivateKey, PublicKey, KeyPair and CurvePoint conform to Codable in order to make data persistence easier.
 
 ### Deprecated
 

--- a/Sources/ImmutableXCore/Crypto/Keys/KeyPair.swift
+++ b/Sources/ImmutableXCore/Crypto/Keys/KeyPair.swift
@@ -2,7 +2,12 @@ import BigInt
 import Foundation
 
 /// Elliptic Curve generated key pair containing a ``PrivateKey`` and a ``PublicKey``
-public struct KeyPair: Equatable {
+public struct KeyPair: Equatable, Codable {
+    enum CodingKeys: String, CodingKey {
+        case privateKey = "private_key"
+        case publicKey = "public_key"
+    }
+
     public let privateKey: PrivateKey
     public let publicKey: PublicKey
 

--- a/Sources/ImmutableXCore/Crypto/Keys/PrivateKey.swift
+++ b/Sources/ImmutableXCore/Crypto/Keys/PrivateKey.swift
@@ -2,7 +2,7 @@ import BigInt
 import Foundation
 
 /// Elliptic Curve generated private key
-public struct PrivateKey: Equatable {
+public struct PrivateKey: Equatable, Codable {
     public let number: BigInt
 
     public var asData: Data {

--- a/Sources/ImmutableXCore/Crypto/Keys/PublicKey.swift
+++ b/Sources/ImmutableXCore/Crypto/Keys/PublicKey.swift
@@ -2,7 +2,7 @@ import BigInt
 import Foundation
 
 /// Elliptic Curve generated public key
-public struct PublicKey: Equatable {
+public struct PublicKey: Equatable, Codable {
     public let point: CurvePoint
     public let number: BigInt
 

--- a/Sources/ImmutableXCore/Crypto/Stark/CurvePoint.swift
+++ b/Sources/ImmutableXCore/Crypto/Stark/CurvePoint.swift
@@ -2,7 +2,7 @@ import BigInt
 import Foundation
 
 /// A representation of an Affine Elliptic Curve Point
-public struct CurvePoint: Equatable {
+public struct CurvePoint: Equatable, Codable {
     public let x: BigInt
     public let y: BigInt
 


### PR DESCRIPTION
Make PrivateKey, PublicKey, KeyPair and CurvePoint conform to Codable in order to make data persistence easier.

This change has no impact in maintainability since Swift auto-synthesises the protocol conformance automatically.

I'll leave these changes unreleased for now, and push a new release in a few days/weeks, in case other changes are needed.