### PR TITLE
refactor: remove XCTWaiter from throw assert

### DIFF
--- a/Tests/ImmutableXCoreTests/Custom APIs/ExchangesAPITests.swift
+++ b/Tests/ImmutableXCoreTests/Custom APIs/ExchangesAPITests.swift
@@ -17,10 +17,10 @@ final class ExchangesAPITests: XCTestCase {
         XCTAssertEqual(response.id, 123)
     }
 
-    func testGetTransactionIdFailure() {
+    func testGetTransactionIdFailure() async {
         builderMock.mock(Result<Response<GetSignedMoonpayResponse>, ErrorResponse>.failure(.error(400, nil, nil, DummyError.something)))
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await self.exchangesAPI.getTransactionId(GetTransactionIdRequest(walletAddress: "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f", provider: .moonpay))
         }
     }
@@ -33,10 +33,10 @@ final class ExchangesAPITests: XCTestCase {
         XCTAssertEqual(response.currencyCodes, ["code": "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f"])
     }
 
-    func testGetCurrenciesFailure() {
+    func testGetCurrenciesFailure() async {
         builderMock.mock(Result<Response<[CurrencyCode]>, ErrorResponse>.failure(.error(400, nil, nil, DummyError.something)))
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await self.exchangesAPI.getCurrencies(address: "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f")
         }
     }

--- a/Tests/ImmutableXCoreTests/Custom APIs/MoonpayAPITests.swift
+++ b/Tests/ImmutableXCoreTests/Custom APIs/MoonpayAPITests.swift
@@ -30,10 +30,10 @@ final class MoonpayAPITests: XCTestCase {
         XCTAssertEqual(url, "https://buy-staging.moonpay.io/?apiKey=pk_test_nGdsu1IBkjiFzmEvN8ddf4gM9GNy5Sgz&baseCurrencyCode=usd&colorCode=%23#008000&externalTransactionId=123&walletAddress=0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f&walletAddresses=%7B%22gods_immutable%22%3A%220xa76e3eeb2f7143165618ab8feaabcd395b6fac7f%22%7D&signature=signature")
     }
 
-    func testGetBuyCryptoURLFailure() {
+    func testGetBuyCryptoURLFailure() async {
         builderMock.mock(Result<Response<GetSignedMoonpayResponse>, ErrorResponse>.failure(.error(400, nil, nil, DummyError.something)))
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await self.moonpayAPI.getBuyCryptoURL(request)
         }
     }

--- a/Tests/ImmutableXCoreTests/ImmutableXCoreTests.swift
+++ b/Tests/ImmutableXCoreTests/ImmutableXCoreTests.swift
@@ -68,12 +68,12 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(response, createTradeResponseStub1)
     }
 
-    func testBuyFlowFailureAsync() {
+    func testBuyFlowFailureAsync() async {
         let buyCompanion = BuyWorkflowCompanion()
         buyCompanion.throwableError = DummyError.something
         buyWorkflow.mock(buyCompanion, id: "1")
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await self.core.buy(orderId: "1", fees: [feeEntryStub1], signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
@@ -120,12 +120,12 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(response, createOrderResponseStub1)
     }
 
-    func testSellFlowFailureAsync() {
+    func testSellFlowFailureAsync() async {
         let sellCompanion = SellWorkflowCompanion()
         sellCompanion.throwableError = DummyError.something
         sellWorkflow.mock(sellCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await self.core.sell(asset: erc721AssetStub1, sellToken: erc20AssetStub1, fees: [], signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
@@ -172,12 +172,12 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(response, cancelOrderResponseStub1)
     }
 
-    func testCancelOrderFlowFailureAsync() {
+    func testCancelOrderFlowFailureAsync() async {
         let cancelOrderCompanion = CancelOrderWorkflowCompanion()
         cancelOrderCompanion.throwableError = DummyError.something
         cancelOrderWorkflow.mock(cancelOrderCompanion, id: "1")
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await self.core.cancelOrder(orderId: "1", signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
@@ -224,12 +224,12 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(response, createTransferResponseStub1)
     }
 
-    func testTransferFlowFailureAsync() {
+    func testTransferFlowFailureAsync() async {
         let transferCompanion = TransferWorkflowCompanion()
         transferCompanion.throwableError = DummyError.something
         transferWorkflowMock.mock(transferCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await self.core.transfer(token: ETHAsset(quantity: "10"), recipientAddress: "address", signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
@@ -277,12 +277,12 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(registerWorkflowMock.companion.callsCount, 1)
     }
 
-    func testRegisterFlowFailureAsync() {
+    func testRegisterFlowFailureAsync() async {
         let registerCompanion = RegisterWorkflowCompanion()
         registerCompanion.throwableError = DummyError.something
         registerWorkflowMock.mock(registerCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await self.core.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock())
         }
     }
@@ -330,12 +330,12 @@ final class ImmutableXCoreTests: XCTestCase {
         XCTAssertEqual(url, "expected url")
     }
 
-    func testBuyCryptoFlowFailureAsync() {
+    func testBuyCryptoFlowFailureAsync() async {
         let buyCryptoCompanion = BuyCryptoWorkflowCompanion()
         buyCryptoCompanion.throwableError = DummyError.something
         buyCryptoWorkflowMock.mock(buyCryptoCompanion)
 
-        XCTAssertThrowsErrorAsync {
+        await XCTAssertThrowsErrorAsync {
             _ = try await self.core.buyCryptoURL(signer: SignerMock())
         }
     }

--- a/Tests/ImmutableXCoreTests/Workflows/BuyCryptoWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/BuyCryptoWorkflowTests.swift
@@ -45,12 +45,12 @@ final class BuyCryptoWorkflowTests: XCTestCase {
         XCTAssertEqual(response, "expected url")
     }
 
-    func testBuyCryptoURLThrowsWhenNotRegistered() {
+    func testBuyCryptoURLThrowsWhenNotRegistered() async {
         let usersCompanion = UsersAPIMockGetUsersCompanion()
         usersCompanion.returnValue = GetUsersApiResponse(accounts: [])
         usersAPI.mock(usersCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyCryptoWorkflow.buyCryptoURL(
                 colorCodeHex: "#000000",
                 signer: SignerMock(),
@@ -62,12 +62,12 @@ final class BuyCryptoWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyCryptoURLThrowsWhenTransactionIdFails() {
+    func testBuyCryptoURLThrowsWhenTransactionIdFails() async {
         let transactionCompanion = ExchangesAPIMockTransactionIdCompanion()
         transactionCompanion.throwableError = DummyError.something
         exchangesAPI.mock(transactionCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyCryptoWorkflow.buyCryptoURL(
                 colorCodeHex: "#000000",
                 signer: SignerMock(),
@@ -79,12 +79,12 @@ final class BuyCryptoWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyCryptoURLThrowsWhenSupportedCurrenciesFails() {
+    func testBuyCryptoURLThrowsWhenSupportedCurrenciesFails() async {
         let currenciesCompanion = ExchangesAPIMockCurrenciesCompanion()
         currenciesCompanion.throwableError = DummyError.something
         exchangesAPI.mock(currenciesCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyCryptoWorkflow.buyCryptoURL(
                 colorCodeHex: "#000000",
                 signer: SignerMock(),
@@ -96,12 +96,12 @@ final class BuyCryptoWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyCryptoURLThrowsWhenBuyCryptoFails() {
+    func testBuyCryptoURLThrowsWhenBuyCryptoFails() async {
         let buyCryptoComanion = MoonpayAPIMockBuyCryptoURLCompanion()
         buyCryptoComanion.throwableError = DummyError.something
         moonpayAPI.mock(buyCryptoComanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyCryptoWorkflow.buyCryptoURL(
                 colorCodeHex: "#000000",
                 signer: SignerMock(),

--- a/Tests/ImmutableXCoreTests/Workflows/BuyWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/BuyWorkflowTests.swift
@@ -37,8 +37,8 @@ final class BuyWorkflowTests: XCTestCase {
         XCTAssertEqual(response, createTradeResponseStub1)
     }
 
-    func testBuyFlowThrowsWhenFeePercentageIsInvalid() {
-        XCTAssertThrowsErrorAsync { [unowned self] in
+    func testBuyFlowThrowsWhenFeePercentageIsInvalid() async {
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [FeeEntry(address: "address", feePercentage: nil)],
@@ -50,8 +50,8 @@ final class BuyWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyFlowThrowsWhenFeeAddressIsInvalid() {
-        XCTAssertThrowsErrorAsync { [unowned self] in
+    func testBuyFlowThrowsWhenFeeAddressIsInvalid() async {
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [FeeEntry(address: nil, feePercentage: 2)],
@@ -63,11 +63,11 @@ final class BuyWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyFlowThrowsWhenPurchaseOwnOrder() {
+    func testBuyFlowThrowsWhenPurchaseOwnOrder() async {
         let signer = SignerMock()
         signer.getAddressReturnValue = orderActiveStub2.user
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],
@@ -79,12 +79,12 @@ final class BuyWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyFlowThrowsWhenOrderStatusIsNotActive() {
+    func testBuyFlowThrowsWhenOrderStatusIsNotActive() async {
         let orderCompanion = OrdersAPIMockGetCompanion()
         orderCompanion.returnValue = orderFilledStub1
         ordersAPI.mock(orderCompanion, id: "1")
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],
@@ -96,12 +96,12 @@ final class BuyWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyFlowThrowsWhenGetOrderFails() {
+    func testBuyFlowThrowsWhenGetOrderFails() async {
         let orderCompanion = OrdersAPIMockGetCompanion()
         orderCompanion.throwableError = DummyError.something
         ordersAPI.mock(orderCompanion, id: "1")
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],
@@ -113,12 +113,12 @@ final class BuyWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyFlowThrowsWhenGetSignableTradeFails() {
+    func testBuyFlowThrowsWhenGetSignableTradeFails() async {
         let tradeGetCompanion = TradesAPIMockGetCompanion()
         tradeGetCompanion.throwableError = DummyError.something
         tradesAPI.mock(tradeGetCompanion, id: 1)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],
@@ -130,12 +130,12 @@ final class BuyWorkflowTests: XCTestCase {
         }
     }
 
-    func testBuyFlowThrowsWhenCreateSignableTradeFails() {
+    func testBuyFlowThrowsWhenCreateSignableTradeFails() async {
         let tradeCreateCompanion = TradesAPIMockCreateCompanion()
         tradeCreateCompanion.throwableError = DummyError.something
         tradesAPI.mock(tradeCreateCompanion, id: 1)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await BuyWorkflow.buy(
                 orderId: "1",
                 fees: [],

--- a/Tests/ImmutableXCoreTests/Workflows/CancelOrderWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/CancelOrderWorkflowTests.swift
@@ -29,12 +29,12 @@ final class CancelOrderWorkflowTests: XCTestCase {
         XCTAssertEqual(response, cancelOrderResponseStub1)
     }
 
-    func testCancelFlowThrowsWhenGetSignableCancelOrderFails() {
+    func testCancelFlowThrowsWhenGetSignableCancelOrderFails() async {
         let signableCompanion = OrdersAPIMockGetSignableCancelCompanion()
         signableCompanion.throwableError = DummyError.something
         ordersAPI.mock(signableCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await CancelOrderWorkflow.cancel(
                 orderId: "1",
                 signer: SignerMock(),
@@ -44,12 +44,12 @@ final class CancelOrderWorkflowTests: XCTestCase {
         }
     }
 
-    func testCancelFlowThrowsWhenCancelOrderFails() {
+    func testCancelFlowThrowsWhenCancelOrderFails() async {
         let cancelOrderCompanion = OrdersAPIMockCancelOrderCompanion()
         cancelOrderCompanion.throwableError = DummyError.something
         ordersAPI.mock(cancelOrderCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await CancelOrderWorkflow.cancel(
                 orderId: "1",
                 signer: SignerMock(),

--- a/Tests/ImmutableXCoreTests/Workflows/RegisterWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/RegisterWorkflowTests.swift
@@ -46,12 +46,12 @@ final class RegisterWorkflowTests: XCTestCase {
         XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
     }
 
-    func testRegistrationThrowsIfGetUsersResponseFails() {
+    func testRegistrationThrowsIfGetUsersResponseFails() async {
         let usersCompanion = UsersAPIMockGetUsersCompanion()
         usersCompanion.throwableError = ErrorResponse.error(400, nil, nil, DummyError.something)
         usersAPI.mock(usersCompanion)
 
-        let error = XCTAssertThrowsErrorAsync { [unowned self] in
+        let error = await XCTAssertThrowsErrorAsync {
             _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: self.usersAPI)
         }
 
@@ -61,12 +61,12 @@ final class RegisterWorkflowTests: XCTestCase {
         XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
     }
 
-    func testRegistrationThrowsIfSignableResponseFails() {
+    func testRegistrationThrowsIfSignableResponseFails() async {
         let signableCompanion = UsersAPIMockGetSignableCompanion()
         signableCompanion.throwableError = DummyError.something
         usersAPI.mock(signableCompanion)
 
-        let error = XCTAssertThrowsErrorAsync { [unowned self] in
+        let error = await XCTAssertThrowsErrorAsync {
             _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: self.usersAPI)
         }
 
@@ -76,12 +76,12 @@ final class RegisterWorkflowTests: XCTestCase {
         XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
     }
 
-    func testRegistrationThrowsIfRegisterResponseFails() {
+    func testRegistrationThrowsIfRegisterResponseFails() async {
         let registerCompanion = UsersAPIMockRegisterCompanion()
         registerCompanion.throwableError = DummyError.something
         usersAPI.mock(registerCompanion)
 
-        let error = XCTAssertThrowsErrorAsync { [unowned self] in
+        let error = await XCTAssertThrowsErrorAsync {
             _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: self.usersAPI)
         }
 

--- a/Tests/ImmutableXCoreTests/Workflows/SellWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/SellWorkflowTests.swift
@@ -31,12 +31,12 @@ final class SellWorkflowTests: XCTestCase {
         XCTAssertEqual(response, createOrderResponseStub1)
     }
 
-    func testSellFlowFailureWhenSignableOrderThrows() {
+    func testSellFlowFailureWhenSignableOrderThrows() async {
         let signableCompanion = OrdersAPIMockGetSignableCompanion()
         signableCompanion.throwableError = DummyError.something
         ordersAPI.mock(signableCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await SellWorkflow.sell(
                 asset: erc721AssetStub1,
                 sellToken: erc20AssetStub1,
@@ -48,12 +48,12 @@ final class SellWorkflowTests: XCTestCase {
         }
     }
 
-    func testSellFlowFailureWhenCreateOrderThrows() {
+    func testSellFlowFailureWhenCreateOrderThrows() async {
         let createOrderCompanion = OrdersAPIMockCreateOrderCompanion()
         createOrderCompanion.throwableError = DummyError.something
         ordersAPI.mock(createOrderCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await SellWorkflow.sell(
                 asset: erc721AssetStub1,
                 sellToken: erc20AssetStub1,

--- a/Tests/ImmutableXCoreTests/Workflows/TransferWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/TransferWorkflowTests.swift
@@ -57,12 +57,12 @@ final class TransferWorkflowTests: XCTestCase {
         XCTAssertEqual(response, createTransferResponseStub1)
     }
 
-    func testTransferFlowFailsOnSignableTransferError() {
+    func testTransferFlowFailsOnSignableTransferError() async {
         let signableCompanion = TransfersAPIMockGetSignableCompanion()
         signableCompanion.throwableError = DummyError.something
         transfersAPI.mock(signableCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await TransferWorkflow.transfer(
                 token: erc721Token,
                 recipientAddress: recipientAddress,
@@ -73,12 +73,12 @@ final class TransferWorkflowTests: XCTestCase {
         }
     }
 
-    func testTransferFlowFailsOnInvalidSignableResponse() {
+    func testTransferFlowFailsOnInvalidSignableResponse() async {
         let signableCompanion = TransfersAPIMockGetSignableCompanion()
         signableCompanion.returnValue = signableTransferResponseStub2
         transfersAPI.mock(signableCompanion)
 
-        XCTAssertThrowsErrorAsync { [unowned self] in
+        await XCTAssertThrowsErrorAsync {
             _ = try await TransferWorkflow.transfer(
                 token: erc721Token,
                 recipientAddress: recipientAddress,

--- a/Tests/ImmutableXCoreTests/XCTestCase+Extensions.swift
+++ b/Tests/ImmutableXCoreTests/XCTestCase+Extensions.swift
@@ -4,27 +4,19 @@ import XCTest
 extension XCTestCase {
     /// Expects that the async code will throw
     @discardableResult
-    func XCTAssertThrowsErrorAsync(testName: String = #function, file: StaticString = #filePath, line: UInt = #line, timeout: TimeInterval = 20, test: @escaping () async throws -> Void) -> Error? {
-        var thrownError: Error?
-        let errorHandler = { thrownError = $0 }
-        let expectation = expectation(description: testName)
-
-        Task {
-            do {
-                try await test()
-            } catch {
-                errorHandler(error)
-            }
-
-            expectation.fulfill()
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: timeout), .completed, file: file, line: line)
-
-        if thrownError == nil {
+    func XCTAssertThrowsErrorAsync(
+        testName: String = #function,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        test: () async throws -> Void
+    ) async -> Error? {
+        do {
+            try await test()
             XCTFail("\(testName) should have failed", file: file, line: line)
+            return nil
+        } catch {
+            // Success
+            return error
         }
-
-        return thrownError
     }
 }


### PR DESCRIPTION
XCTWaiter does not go well with async methods, making it hang when running tests against the iOS simulators for whatever reason.

Turns out there's a simpler way of reaching the same outcome just by using purely async/await.