### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ for now removed features.
 
 for any bug fixes.
 
+## [0.4.0] - 2022-10-21
+
+### Changed
+
+- (Breaking): rename ImmutableXCore to ImmutableX
+This follows the new spec for the core SDKs that will come to swift shortly.
+
+- (Breaking): replace ropsten environment for sandbox
+Ropsten has been deprecated and won't work anymore. Sandbox is the preferred testing environment.
+
+### Fixed
+
+- re-include macos as a Cocoapods target
+The Core SDK is generic enough that it should work on macOS. It had accidentally been removed on 0.3.1.
+
 ## [0.3.1] - 2022-10-19
 
 ### Removed

--- a/ImmutableXCore.podspec
+++ b/ImmutableXCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                  = 'ImmutableXCore'
-    spec.version               = '0.3.1'
+    spec.version               = '0.4.0'
     spec.summary               = 'The Immutable X Core SDK Swift for applications written on the Immutable X platform.'
 
     spec.description           = <<-DESC
@@ -12,7 +12,7 @@ Pod::Spec.new do |spec|
     spec.license               = { :type => 'Apache License 2.0', :file => 'LICENSE' }
     spec.author                = { 'Immutable' => 'opensource@immutable.com'}
 
-    spec.source                = { :git => 'https://github.com/immutable/imx-core-sdk-swift.git', :tag => "v0.3.1" }
+    spec.source                = { :git => 'https://github.com/immutable/imx-core-sdk-swift.git', :tag => "v0.4.0" }
     spec.source_files          = 'Sources/**/*.swift'
 
     spec.swift_version         = '5.7'

--- a/ImmutableXCore.podspec
+++ b/ImmutableXCore.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |spec|
     spec.swift_version         = '5.7'
 
     spec.ios.deployment_target = '13'
+    spec.osx.deployment_target = '10.15'
 
     spec.dependency 'AnyCodable-FlightSchool', '~> 0.6'
     spec.dependency 'BigInt', '~> 5.2.0'

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The Core SDK must be initialised before any of its classes are used. Upon initia
 For example, you initialise the SDK and retrieve a URL to buy crypto through Moonpay:
 
 ```swift
-ImmutableX.initialize(base: .ropsten)
+ImmutableX.initialize(base: .sandbox)
 
 let url = try await ImmutableX.shared.buyCryptoURL(signer: signer)
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/immutable/imx-core-sdk-swift.git", from: "0.3.1")
+    .package(url: "https://github.com/immutable/imx-core-sdk-swift.git", from: "0.4.0")
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ The Core SDK must be initialised before any of its classes are used. Upon initia
 For example, you initialise the SDK and retrieve a URL to buy crypto through Moonpay:
 
 ```swift
-ImmutableXCore.initialize(base: .ropsten)
+ImmutableX.initialize(base: .ropsten)
 
-let url = try await ImmutableXCore.shared.buyCryptoURL(signer: signer)
+let url = try await ImmutableX.shared.buyCryptoURL(signer: signer)
 ```
 
 ### Workflow Functions
 
-Utility functions accessed via `ImmutableXCore.shared` that will chain necessary API calls to complete a process or perform a transaction.
+Utility functions accessed via `ImmutableX.shared` that will chain necessary API calls to complete a process or perform a transaction.
 
 - Register a user with Immutable X
 - Buy cryptocurrency via Moonpay

--- a/Sources/ImmutableXCore/Config/ImmutableXBase.swift
+++ b/Sources/ImmutableXCore/Config/ImmutableXBase.swift
@@ -1,14 +1,17 @@
 /// An enum for defining the environment the SDK will communicate with
 public enum ImmutableXBase {
+    /// Ethereum network
     case production
-    case ropsten
+
+    /// The default test network (currently Goerli)
+    case sandbox
 
     internal var publicApiUrl: String {
         switch self {
         case .production:
             return "https://api.x.immutable.com"
-        case .ropsten:
-            return "https://api.ropsten.x.immutable.com"
+        case .sandbox:
+            return "https://api.sandbox.x.immutable.com"
         }
     }
 
@@ -16,7 +19,7 @@ public enum ImmutableXBase {
         switch self {
         case .production:
             return "pk_live_lgGxv3WyWjnWff44ch4gmolN0953"
-        case .ropsten:
+        case .sandbox:
             return "pk_test_nGdsu1IBkjiFzmEvN8ddf4gM9GNy5Sgz"
         }
     }
@@ -25,7 +28,7 @@ public enum ImmutableXBase {
         switch self {
         case .production:
             return "https://buy.moonpay.io"
-        case .ropsten:
+        case .sandbox:
             return "https://buy-staging.moonpay.io"
         }
     }

--- a/Sources/ImmutableXCore/Config/ImmutableXHTTPLoggingLevel.swift
+++ b/Sources/ImmutableXCore/Config/ImmutableXHTTPLoggingLevel.swift
@@ -1,4 +1,4 @@
-/// Defines the level of logging for ImmutableXCore network calls.
+/// Defines the level of logging for ImmutableX network calls.
 ///
 /// - Note: Logs are only available in debug mode.
 public enum ImmutableXHTTPLoggingLevel {

--- a/Sources/ImmutableXCore/Crypto/BIP32/BIP32Key.swift
+++ b/Sources/ImmutableXCore/Crypto/BIP32/BIP32Key.swift
@@ -7,7 +7,7 @@ struct BIP32Key {
     ///     - seed: seed data for derivation, e.g. personal signature
     ///     - path: hashed values in the expected format as per Starkware docs `m/purpose'/layer'/application'/ethAddress1'/ethAddress2'/index`
     /// - Returns: derived private key hex
-    /// - Throws: ``ImmutableXCoreError/invalidKeyData`` if data is not valid
+    /// - Throws: ``ImmutableXError/invalidKeyData`` if data is not valid
     ///
     /// https://docs.starkware.co/starkex-v4/crypto/key-derivation
     /// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
@@ -23,7 +23,7 @@ struct BIP32Key {
             let hardened = path.hasSuffix("'")
             let sanitizedPath = path.replacingOccurrences(of: "'", with: "")
 
-            guard let index = UInt32(sanitizedPath), edge & index == 0 else { throw ImmutableXCoreError.invalidKeyData }
+            guard let index = UInt32(sanitizedPath), edge & index == 0 else { throw ImmutableXError.invalidKeyData }
 
             var data = Data()
 

--- a/Sources/ImmutableXCore/Crypto/Keys/PrivateKey.swift
+++ b/Sources/ImmutableXCore/Crypto/Keys/PrivateKey.swift
@@ -9,17 +9,17 @@ public struct PrivateKey: Equatable, Codable {
         number.as256bitLongData()
     }
 
-    /// - Throws: ``ImmutableXCoreError/invalidKeyData`` if given `number` is not within curve range
+    /// - Throws: ``ImmutableXError/invalidKeyData`` if given `number` is not within curve range
     public init(number: BigInt) throws {
         // Private Key must be in the curve range
-        guard case 1 ..< StarkCurve.N = number else { throw ImmutableXCoreError.invalidKeyData }
+        guard case 1 ..< StarkCurve.N = number else { throw ImmutableXError.invalidKeyData }
         self.number = number
     }
 
-    /// - Throws: ``ImmutableXCoreError/invalidKeyData`` if given `hex` is not valid or within curve range
+    /// - Throws: ``ImmutableXError/invalidKeyData`` if given `hex` is not valid or within curve range
     public init(hex: String) throws {
         guard let number = BigInt(hexString: hex) else {
-            throw ImmutableXCoreError.invalidKeyData
+            throw ImmutableXError.invalidKeyData
         }
         try self.init(number: number)
     }

--- a/Sources/ImmutableXCore/Crypto/Stark/StarkKey.swift
+++ b/Sources/ImmutableXCore/Crypto/Stark/StarkKey.swift
@@ -14,7 +14,7 @@ public extension StarkKey {
     /// Generate a Stark key pair from a L1 wallet.
     /// - Parameter signer: the signer that the key pair will be derived from
     /// - Returns: Stark key pair as ``KeyPair``
-    /// - Throws: ``ImmutableXCoreError``
+    /// - Throws: ``ImmutableXError``
     static func generateKeyPair(from signer: Signer) async throws -> KeyPair {
         let address = try await signer.getAddress()
         let signature = try await signer.signMessage(Constants.starkMessage)
@@ -23,17 +23,17 @@ public extension StarkKey {
 
     /// Generate a Stark key pair from a L1 wallet.
     /// - Parameter signer: the signer that the key pair will be derived from
-    /// - Returns: a Stark key pair as ``KeyPair`` if successful or an ``ImmutableXCoreError``
+    /// - Returns: a Stark key pair as ``KeyPair`` if successful or an ``ImmutableXError``
     ///  error through the `onCompletion` callback
     ///
     /// - Note: `onCompletion` is executed on the Main Thread
-    static func generateKeyPair(from signer: Signer, onCompletion: @escaping (Result<KeyPair, ImmutableXCoreError>) -> Void) {
+    static func generateKeyPair(from signer: Signer, onCompletion: @escaping (Result<KeyPair, ImmutableXError>) -> Void) {
         Task { @MainActor in
             do {
                 let pair = try await generateKeyPair(from: signer)
                 onCompletion(.success(pair))
             } catch {
-                onCompletion(.failure(error.asImmutableXCoreError))
+                onCompletion(.failure(error.asImmutableXError))
             }
         }
     }
@@ -42,7 +42,7 @@ public extension StarkKey {
     /// - Parameter signature: the 's' variable of the signature
     /// - Parameter ethereumAddress: the connected wallet address
     /// - Returns: Stark key pair as ``KeyPair``
-    /// - Throws: ``ImmutableXCoreError``
+    /// - Throws: ``ImmutableXError``
     static func generateKeyPairFromRawSignature(_ signature: String, ethereumAddress: String) throws -> KeyPair {
         // https://github.com/ethers-io/ethers.js/blob/3de1b815014b10d223a42e524fe9c25f9087293b/packages/bytes/src.ts/index.ts#L347
         let seed = signature.dropHexPrefix[64 ..< 128]

--- a/Sources/ImmutableXCore/Crypto/Stark/StarkSignature.swift
+++ b/Sources/ImmutableXCore/Crypto/Stark/StarkSignature.swift
@@ -5,10 +5,10 @@ public struct StarkSignature: Equatable {
     public let r: BigInt
     public let s: BigInt
 
-    /// - Throws: ``ImmutableXCoreError/invalidStarkSignature`` if given `r` or `s` are not within curve range
+    /// - Throws: ``ImmutableXError/invalidStarkSignature`` if given `r` or `s` are not within curve range
     public init(r: BigInt, s: BigInt) throws {
         guard r < StarkCurve.P, r > BigInt.zero, s < StarkCurve.N, s > BigInt.zero else {
-            throw ImmutableXCoreError.invalidStarkSignature
+            throw ImmutableXError.invalidStarkSignature
         }
 
         self.r = r

--- a/Sources/ImmutableXCore/Custom APIs/MoonpayAPI.swift
+++ b/Sources/ImmutableXCore/Custom APIs/MoonpayAPI.swift
@@ -7,7 +7,7 @@ struct GetBuyCryptoURLRequest: Codable {
     let walletAddress: String
     let currencies: [String: String]
 
-    init(apiKey: String = ImmutableXCore.shared.base.moonpayApiKey, colorCodeHex: String, externalTransaction: Int, walletAddress: String, currencies: [String: String]) {
+    init(apiKey: String = ImmutableX.shared.base.moonpayApiKey, colorCodeHex: String, externalTransaction: Int, walletAddress: String, currencies: [String: String]) {
         self.apiKey = apiKey
         self.colorCodeHex = colorCodeHex
         self.externalTransaction = externalTransaction
@@ -44,9 +44,9 @@ struct GetSignedMoonpayResponse: Codable {
 class MoonpayAPI {
     static let encodedEqualSign = "%3D"
     let requestBuilderFactory: RequestBuilderFactory
-    let core: ImmutableXCore
+    let core: ImmutableX
 
-    init(requestBuilderFactory: RequestBuilderFactory = OpenAPIClientAPI.requestBuilderFactory, core: ImmutableXCore = ImmutableXCore.shared) {
+    init(requestBuilderFactory: RequestBuilderFactory = OpenAPIClientAPI.requestBuilderFactory, core: ImmutableX = ImmutableX.shared) {
         self.requestBuilderFactory = requestBuilderFactory
         self.core = core
     }

--- a/Sources/ImmutableXCore/Extensions/Optional+Extensions.swift
+++ b/Sources/ImmutableXCore/Extensions/Optional+Extensions.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 extension Optional {
-    /// Return wrapped value if exists or thorws given ``ImmutableXCoreError`` otherwise
-    func orThrow(_ error: @autoclosure () -> ImmutableXCoreError) throws -> Wrapped {
+    /// Return wrapped value if exists or thorws given ``ImmutableXError`` otherwise
+    func orThrow(_ error: @autoclosure () -> ImmutableXError) throws -> Wrapped {
         if let wrapped = self {
             return wrapped
         } else {

--- a/Sources/ImmutableXCore/Generated/APIs.swift
+++ b/Sources/ImmutableXCore/Generated/APIs.swift
@@ -14,13 +14,13 @@ import Foundation
 public typealias OpenAPIClient = OpenAPIClientAPI
 
 open class OpenAPIClientAPI {
-    public static var customHeaders: [String: String] = ["x-sdk-version": "imx-core-sdk-swift-\(ImmutableXCore.shared.sdkVersion)"]
+    public static var customHeaders: [String: String] = ["x-sdk-version": "imx-core-sdk-swift-\(ImmutableX.shared.sdkVersion)"]
     public static var credential: URLCredential?
     public static var requestBuilderFactory: RequestBuilderFactory = URLSessionRequestBuilderFactory()
     public static var apiResponseQueue: DispatchQueue = .main
 
     public static var basePath: String {
-        return ImmutableXCore.shared.base.publicApiUrl
+        return ImmutableX.shared.base.publicApiUrl
     }
 }
 

--- a/Sources/ImmutableXCore/Generated/URLSessionImplementations.swift
+++ b/Sources/ImmutableXCore/Generated/URLSessionImplementations.swift
@@ -641,7 +641,7 @@ private struct Logger {
 
     static func log(_ request: URLRequest, parameters: [String: Any]?) {
 #if DEBUG
-        guard case let .calls(including: areas) = ImmutableXCore.shared.logLevel else { return }
+        guard case let .calls(including: areas) = ImmutableX.shared.logLevel else { return }
 
         var privateLog = ""
 
@@ -681,7 +681,7 @@ private struct Logger {
 
     static func log(_ request: URLRequest, data: Data?, response: URLResponse?, error: Error?) {
 #if DEBUG
-        guard case let .calls(including: areas) = ImmutableXCore.shared.logLevel else { return }
+        guard case let .calls(including: areas) = ImmutableX.shared.logLevel else { return }
 
         let response = response as? HTTPURLResponse
         var privateLog = ""

--- a/Sources/ImmutableXCore/ImmutableX.swift
+++ b/Sources/ImmutableXCore/ImmutableX.swift
@@ -1,18 +1,18 @@
 import Foundation
 
 // swiftlint:disable function_parameter_count
-public struct ImmutableXCore {
-    /// A shared instance of ``ImmutableXCore`` that holds configuration for ``base``, ``logLevel`` and
+public struct ImmutableX {
+    /// A shared instance of ``ImmutableX`` that holds configuration for ``base``, ``logLevel`` and
     /// a set o utility methods for the most common workflows for the core SDK.
     ///
     /// - Note: ``initialize(base:logLevel:)`` must be called before this instance
     /// is accessed.
-    public internal(set) static var shared: ImmutableXCore!
+    public internal(set) static var shared: ImmutableX!
 
     /// The environment the SDK will communicate with. Defaults to `.ropsten`.
     public let base: ImmutableXBase
 
-    /// Defines the level of logging for ImmutableXCore network calls. Defaults to `.none`.
+    /// Defines the level of logging for ImmutableX network calls. Defaults to `.none`.
     ///
     ///  Setting `logLevel` to `.calls(including: [])` will log all requests and responses with HTTP Method and URL.
     ///  For richer logging include extra details of the calls to be logged, e.g.
@@ -48,9 +48,9 @@ public struct ImmutableXCore {
         self.buyCryptoWorkflow = buyCryptoWorkflow
     }
 
-    /// Initializes the SDK with the given ``base`` and ``logLevel`` by assigning a shared instance accessible via `ImmutableXCore.shared`.
+    /// Initializes the SDK with the given ``base`` and ``logLevel`` by assigning a shared instance accessible via `ImmutableX.shared`.
     public static func initialize(base: ImmutableXBase = .ropsten, logLevel: ImmutableXHTTPLoggingLevel = .none) {
-        ImmutableXCore.shared = ImmutableXCore(base: base, logLevel: logLevel)
+        ImmutableX.shared = ImmutableX(base: base, logLevel: logLevel)
     }
 
     /// This is a utility function that will chain the necessary calls to buy an existing order.
@@ -61,7 +61,7 @@ public struct ImmutableXCore {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: a ``CreateTradeResponse`` that will provide the Trade id if successful.
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     public func buy(orderId: String, fees: [FeeEntry] = [], signer: Signer, starkSigner: StarkSigner) async throws -> CreateTradeResponse {
         try await buyWorkflow.buy(orderId: orderId, fees: fees, signer: signer, starkSigner: starkSigner)
     }
@@ -74,16 +74,16 @@ public struct ImmutableXCore {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: a ``CreateTradeResponse`` tthat will provide the Trade id if successful
-    ///  or an ``ImmutableXCoreError`` error through the `onCompletion` callback
+    ///  or an ``ImmutableXError`` error through the `onCompletion` callback
     ///
     /// - Note: `onCompletion` is executed on the Main Thread
-    public func buy(orderId: String, fees: [FeeEntry] = [], signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CreateTradeResponse, ImmutableXCoreError>) -> Void) {
+    public func buy(orderId: String, fees: [FeeEntry] = [], signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CreateTradeResponse, ImmutableXError>) -> Void) {
         Task { @MainActor in
             do {
                 let response = try await buyWorkflow.buy(orderId: orderId, fees: fees, signer: signer, starkSigner: starkSigner)
                 onCompletion(.success(response))
             } catch {
-                onCompletion(.failure(error.asImmutableXCoreError))
+                onCompletion(.failure(error.asImmutableXError))
             }
         }
     }
@@ -97,7 +97,7 @@ public struct ImmutableXCore {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: ``CreateOrderResponse`` that will provide the Order id if successful.
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     public func sell(asset: AssetModel, sellToken: AssetModel, fees: [FeeEntry], signer: Signer, starkSigner: StarkSigner) async throws -> CreateOrderResponse {
         try await sellWorkflow.sell(asset: asset, sellToken: sellToken, fees: fees, signer: signer, starkSigner: starkSigner)
     }
@@ -111,16 +111,16 @@ public struct ImmutableXCore {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: a ``CreateOrderResponse`` that will provide the Order id if successful
-    ///  or an ``ImmutableXCoreError`` error through the `onCompletion` callback
+    ///  or an ``ImmutableXError`` error through the `onCompletion` callback
     ///
     /// - Note: `onCompletion` is executed on the Main Thread
-    public func sell(asset: AssetModel, sellToken: AssetModel, fees: [FeeEntry], signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CreateOrderResponse, ImmutableXCoreError>) -> Void) {
+    public func sell(asset: AssetModel, sellToken: AssetModel, fees: [FeeEntry], signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CreateOrderResponse, ImmutableXError>) -> Void) {
         Task { @MainActor in
             do {
                 let response = try await sellWorkflow.sell(asset: asset, sellToken: sellToken, fees: fees, signer: signer, starkSigner: starkSigner)
                 onCompletion(.success(response))
             } catch {
-                onCompletion(.failure(error.asImmutableXCoreError))
+                onCompletion(.failure(error.asImmutableXError))
             }
         }
     }
@@ -132,7 +132,7 @@ public struct ImmutableXCore {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: ``CancelOrderResponse`` that will provide the cancelled Order id if successful.
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     public func cancelOrder(orderId: String, signer: Signer, starkSigner: StarkSigner) async throws -> CancelOrderResponse {
         try await cancelOrderWorkflow.cancel(orderId: orderId, signer: signer, starkSigner: starkSigner)
     }
@@ -144,16 +144,16 @@ public struct ImmutableXCore {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: a ``CancelOrderResponse`` that will provide the cancelled Order id if successful
-    ///  or an ``ImmutableXCoreError`` error through the `onCompletion` callback
+    ///  or an ``ImmutableXError`` error through the `onCompletion` callback
     ///
     /// - Note: `onCompletion` is executed on the Main Thread
-    public func cancelOrder(orderId: String, signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CancelOrderResponse, ImmutableXCoreError>) -> Void) {
+    public func cancelOrder(orderId: String, signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CancelOrderResponse, ImmutableXError>) -> Void) {
         Task { @MainActor in
             do {
                 let response = try await cancelOrderWorkflow.cancel(orderId: orderId, signer: signer, starkSigner: starkSigner)
                 onCompletion(.success(response))
             } catch {
-                onCompletion(.failure(error.asImmutableXCoreError))
+                onCompletion(.failure(error.asImmutableXError))
             }
         }
     }
@@ -166,7 +166,7 @@ public struct ImmutableXCore {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: ``CreateTransferResponse`` that will provide the transfer id if successful.
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     public func transfer(token: AssetModel, recipientAddress: String, signer: Signer, starkSigner: StarkSigner) async throws -> CreateTransferResponse {
         try await transferWorkflow.transfer(token: token, recipientAddress: recipientAddress, signer: signer, starkSigner: starkSigner)
     }
@@ -179,16 +179,16 @@ public struct ImmutableXCore {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: a ``CreateTransferResponse`` that will provide the transfer id if successful
-    ///  or an ``ImmutableXCoreError`` error through the `onCompletion` callback
+    ///  or an ``ImmutableXError`` error through the `onCompletion` callback
     ///
     /// - Note: `onCompletion` is executed on the Main Thread
-    public func transfer(token: AssetModel, recipientAddress: String, signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CreateTransferResponse, ImmutableXCoreError>) -> Void) {
+    public func transfer(token: AssetModel, recipientAddress: String, signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CreateTransferResponse, ImmutableXError>) -> Void) {
         Task { @MainActor in
             do {
                 let response = try await transferWorkflow.transfer(token: token, recipientAddress: recipientAddress, signer: signer, starkSigner: starkSigner)
                 onCompletion(.success(response))
             } catch {
-                onCompletion(.failure(error.asImmutableXCoreError))
+                onCompletion(.failure(error.asImmutableXError))
             }
         }
     }
@@ -199,7 +199,7 @@ public struct ImmutableXCore {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: `Void` if user is registered
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     public func registerOffchain(signer: Signer, starkSigner: StarkSigner) async throws {
         _ = try await registerWorkflow.registerOffchain(signer: signer, starkSigner: starkSigner)
     }
@@ -209,17 +209,17 @@ public struct ImmutableXCore {
     /// - Parameters:
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
-    /// - Returns: `Void` if user is registered or an ``ImmutableXCoreError`` error through
+    /// - Returns: `Void` if user is registered or an ``ImmutableXError`` error through
     /// the `onCompletion` callback
     ///
     /// - Note: `onCompletion` is executed on the Main Thread
-    public func registerOffchain(signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<Void, ImmutableXCoreError>) -> Void) {
+    public func registerOffchain(signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<Void, ImmutableXError>) -> Void) {
         Task { @MainActor in
             do {
                 _ = try await registerWorkflow.registerOffchain(signer: signer, starkSigner: starkSigner)
                 onCompletion(.success(()))
             } catch {
-                onCompletion(.failure(error.asImmutableXCoreError))
+                onCompletion(.failure(error.asImmutableXError))
             }
         }
     }
@@ -231,7 +231,7 @@ public struct ImmutableXCore {
     ///     It is used for buttons, links and highlighted text. Defaults to `#00818e`
     ///     - signer: represents the users L1 wallet to get the address
     /// - Returns: a website URL string to be used to launch a WebView or Browser to buy crypto
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     public func buyCryptoURL(colorCodeHex: String = "#00818e", signer: Signer) async throws -> String {
         try await buyCryptoWorkflow.buyCryptoURL(colorCodeHex: colorCodeHex, signer: signer)
     }
@@ -243,16 +243,16 @@ public struct ImmutableXCore {
     ///     It is used for buttons, links and highlighted text. Defaults to `#00818e`
     ///     - signer: represents the users L1 wallet to get the address
     /// - Returns: a website URL string to be used to launch a WebView or Browser to buy crypto if successful
-    /// or an ``ImmutableXCoreError`` error through the `onCompletion` callback
+    /// or an ``ImmutableXError`` error through the `onCompletion` callback
     ///
     /// - Note: `onCompletion` is executed on the Main Thread
-    public func buyCryptoURL(colorCodeHex: String = "#00818e", signer: Signer, onCompletion: @escaping (Result<String, ImmutableXCoreError>) -> Void) {
+    public func buyCryptoURL(colorCodeHex: String = "#00818e", signer: Signer, onCompletion: @escaping (Result<String, ImmutableXError>) -> Void) {
         Task { @MainActor in
             do {
                 let response = try await buyCryptoWorkflow.buyCryptoURL(colorCodeHex: colorCodeHex, signer: signer)
                 onCompletion(.success(response))
             } catch {
-                onCompletion(.failure(error.asImmutableXCoreError))
+                onCompletion(.failure(error.asImmutableXError))
             }
         }
     }

--- a/Sources/ImmutableXCore/ImmutableX.swift
+++ b/Sources/ImmutableXCore/ImmutableX.swift
@@ -9,7 +9,7 @@ public struct ImmutableX {
     /// is accessed.
     public internal(set) static var shared: ImmutableX!
 
-    /// The environment the SDK will communicate with. Defaults to `.ropsten`.
+    /// The environment the SDK will communicate with. Defaults to `.sandbox`.
     public let base: ImmutableXBase
 
     /// Defines the level of logging for ImmutableX network calls. Defaults to `.none`.
@@ -37,7 +37,7 @@ public struct ImmutableX {
     private let buyCryptoWorkflow: BuyCryptoWorkflow.Type
 
     /// Internal init method that includes dependencies. For the public facing API use ``initialize(base:logLevel:)`` instead.
-    internal init(base: ImmutableXBase = .ropsten, logLevel: ImmutableXHTTPLoggingLevel = .none, buyWorkflow: BuyWorkflow.Type = BuyWorkflow.self, sellWorkflow: SellWorkflow.Type = SellWorkflow.self, cancelOrderWorkflow: CancelOrderWorkflow.Type = CancelOrderWorkflow.self, transferWorkflow: TransferWorkflow.Type = TransferWorkflow.self, registerWorkflow: RegisterWorkflow.Type = RegisterWorkflow.self, buyCryptoWorkflow: BuyCryptoWorkflow.Type = BuyCryptoWorkflow.self) {
+    internal init(base: ImmutableXBase = .sandbox, logLevel: ImmutableXHTTPLoggingLevel = .none, buyWorkflow: BuyWorkflow.Type = BuyWorkflow.self, sellWorkflow: SellWorkflow.Type = SellWorkflow.self, cancelOrderWorkflow: CancelOrderWorkflow.Type = CancelOrderWorkflow.self, transferWorkflow: TransferWorkflow.Type = TransferWorkflow.self, registerWorkflow: RegisterWorkflow.Type = RegisterWorkflow.self, buyCryptoWorkflow: BuyCryptoWorkflow.Type = BuyCryptoWorkflow.self) {
         self.base = base
         self.logLevel = logLevel
         self.buyWorkflow = buyWorkflow
@@ -49,7 +49,7 @@ public struct ImmutableX {
     }
 
     /// Initializes the SDK with the given ``base`` and ``logLevel`` by assigning a shared instance accessible via `ImmutableX.shared`.
-    public static func initialize(base: ImmutableXBase = .ropsten, logLevel: ImmutableXHTTPLoggingLevel = .none) {
+    public static func initialize(base: ImmutableXBase = .sandbox, logLevel: ImmutableXHTTPLoggingLevel = .none) {
         ImmutableX.shared = ImmutableX(base: base, logLevel: logLevel)
     }
 

--- a/Sources/ImmutableXCore/ImmutableX.swift
+++ b/Sources/ImmutableXCore/ImmutableX.swift
@@ -27,7 +27,7 @@ public struct ImmutableX {
     public var logLevel: ImmutableXHTTPLoggingLevel
 
     /// Returns the version of the sdk
-    internal var sdkVersion: String = "0.3.1"
+    internal var sdkVersion: String = "0.4.0"
 
     private let buyWorkflow: BuyWorkflow.Type
     private let sellWorkflow: SellWorkflow.Type

--- a/Sources/ImmutableXCore/Model/AssetModel.swift
+++ b/Sources/ImmutableXCore/Model/AssetModel.swift
@@ -15,7 +15,7 @@ internal extension AssetModel {
     /// Helper function to calculate the quantity field
     func formatQuantity() throws -> String {
         guard let decimalQuantity = Decimal(string: quantity) else {
-            throw ImmutableXCoreError.invalidRequest(reason: "Invalid asset quantity")
+            throw ImmutableXError.invalidRequest(reason: "Invalid asset quantity")
         }
 
         let decimals: Int
@@ -27,7 +27,7 @@ internal extension AssetModel {
         } else if self is ETHAsset {
             decimals = Constants.ETHDecimals
         } else {
-            throw ImmutableXCoreError.invalidRequest(reason: "Unimplemented asset")
+            throw ImmutableXError.invalidRequest(reason: "Unimplemented asset")
         }
 
         return "\(pow(10, decimals) * decimalQuantity)"

--- a/Sources/ImmutableXCore/Utils/CryptoUtil.swift
+++ b/Sources/ImmutableXCore/Utils/CryptoUtil.swift
@@ -57,9 +57,9 @@ struct CryptoUtil {
     /// This function does the opposite operation so that
     /// `truncateToN(fix(message: message)) == message`
     ///
-    ///  - Throws: ``ImmutableXCoreError/invalidSignatureMessageLength`` if message is larger than 63 characters
+    ///  - Throws: ``ImmutableXError/invalidSignatureMessageLength`` if message is larger than 63 characters
     static func fix(message: String) throws -> String {
-        guard message.count < 64 else { throw ImmutableXCoreError.invalidSignatureMessageLength }
+        guard message.count < 64 else { throw ImmutableXError.invalidSignatureMessageLength }
 
         if message.count <= 62 {
             // In this case, msg should not be transformed, as the byteLength() is at most 31,

--- a/Sources/ImmutableXCore/Utils/ImmutableXError.swift
+++ b/Sources/ImmutableXCore/Utils/ImmutableXError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ImmutableXCoreError: Error {
+public enum ImmutableXError: Error {
     /// Error related to deriving or parsing ``PrivateKey`` and ``PublicKey``
     case invalidKeyData
 
@@ -18,9 +18,9 @@ public enum ImmutableXCoreError: Error {
 }
 
 internal extension Error {
-    /// Returns error as ``ImmutableXCoreError/invalidRequest(reason:)`` with `localizedDescription`
-    /// if it's not an ``ImmutableXCoreError``
-    var asImmutableXCoreError: ImmutableXCoreError {
-        self as? ImmutableXCoreError ?? ImmutableXCoreError.invalidRequest(reason: localizedDescription)
+    /// Returns error as ``ImmutableXError/invalidRequest(reason:)`` with `localizedDescription`
+    /// if it's not an ``ImmutableXError``
+    var asImmutableXError: ImmutableXError {
+        self as? ImmutableXError ?? ImmutableXError.invalidRequest(reason: localizedDescription)
     }
 }

--- a/Sources/ImmutableXCore/Workflows/BuyCryptoWorkflow.swift
+++ b/Sources/ImmutableXCore/Workflows/BuyCryptoWorkflow.swift
@@ -9,14 +9,14 @@ class BuyCryptoWorkflow {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - base: the config to be used for API keys and providers URLs
     /// - Returns: a website URL string to be used to launch a WebView or Browser to buy crypto
-    /// - Throws: A variation of ``ImmutableXCoreError``
-    class func buyCryptoURL(colorCodeHex: String, signer: Signer, base: ImmutableXBase = ImmutableXCore.shared.base, moonpayAPI: MoonpayAPI = MoonpayAPI(), exchangesAPI: ExchangesAPI = ExchangesAPI(), usersAPI: UsersAPI.Type = UsersAPI.self) async throws -> String {
+    /// - Throws: A variation of ``ImmutableXError``
+    class func buyCryptoURL(colorCodeHex: String, signer: Signer, base: ImmutableXBase = ImmutableX.shared.base, moonpayAPI: MoonpayAPI = MoonpayAPI(), exchangesAPI: ExchangesAPI = ExchangesAPI(), usersAPI: UsersAPI.Type = UsersAPI.self) async throws -> String {
         let address = try await signer.getAddress()
         let isRegistered = try await RegisterWorkflow.isUserRegistered(address: address, api: usersAPI)
 
         guard isRegistered else {
-            throw ImmutableXCoreError.invalidRequest(
-                reason: "Wallet is not registered. Call ImmutableXCore.shared.registerOffChain() to register your wallet."
+            throw ImmutableXError.invalidRequest(
+                reason: "Wallet is not registered. Call ImmutableX.shared.registerOffChain() to register your wallet."
             )
         }
 

--- a/Sources/ImmutableXCore/Workflows/BuyWorkflow.swift
+++ b/Sources/ImmutableXCore/Workflows/BuyWorkflow.swift
@@ -9,7 +9,7 @@ class BuyWorkflow {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: ``CreateTradeResponse`` that will provide the Trade id if successful.
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     class func buy(orderId: String, fees: [FeeEntry], signer: Signer, starkSigner: StarkSigner, ordersAPI: OrdersAPI.Type = OrdersAPI.self, tradesAPI: TradesAPI.Type = TradesAPI.self) async throws -> CreateTradeResponse {
         let address = try await signer.getAddress()
         let order = try await getOrderDetails(orderId: orderId, fees: fees, api: ordersAPI)
@@ -39,8 +39,8 @@ class BuyWorkflow {
     }
 
     private static func getSignableTrade(order: Order, address: String, fees: [FeeEntry], api: TradesAPI.Type) async throws -> GetSignableTradeResponse {
-        guard order.user != address else { throw ImmutableXCoreError.invalidRequest(reason: "Cannot purchase own order") }
-        guard order.status == OrderStatus.active.rawValue else { throw ImmutableXCoreError.invalidRequest(reason: "Order not available for purchase") }
+        guard order.user != address else { throw ImmutableXError.invalidRequest(reason: "Cannot purchase own order") }
+        guard order.status == OrderStatus.active.rawValue else { throw ImmutableXError.invalidRequest(reason: "Order not available for purchase") }
         return try await Workflow.mapAPIErrors(caller: "Signable trade") {
             try await api.getSignableTrade(
                 getSignableTradeRequest: GetSignableTradeRequest(

--- a/Sources/ImmutableXCore/Workflows/CancelOrderWorkflow.swift
+++ b/Sources/ImmutableXCore/Workflows/CancelOrderWorkflow.swift
@@ -8,7 +8,7 @@ class CancelOrderWorkflow {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: ``CancelOrderResponse`` that will provide the cancelled Order id if successful.
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     class func cancel(orderId: String, signer: Signer, starkSigner: StarkSigner, ordersAPI: OrdersAPI.Type = OrdersAPI.self) async throws -> CancelOrderResponse {
         let address = try await signer.getAddress()
         let signableOrder = try await getSignableCancelOrder(orderId: orderId, api: ordersAPI)

--- a/Sources/ImmutableXCore/Workflows/RegisterWorkflow.swift
+++ b/Sources/ImmutableXCore/Workflows/RegisterWorkflow.swift
@@ -7,7 +7,7 @@ class RegisterWorkflow {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: true if user has been registered or false if user had already been registered
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     class func registerOffchain(signer: Signer, starkSigner: StarkSigner, usersAPI: UsersAPI.Type = UsersAPI.self) async throws -> Bool {
         let address = try await signer.getAddress()
         let starkAddress = try await starkSigner.getAddress()

--- a/Sources/ImmutableXCore/Workflows/SellWorkflow.swift
+++ b/Sources/ImmutableXCore/Workflows/SellWorkflow.swift
@@ -10,7 +10,7 @@ class SellWorkflow {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: ``CreateOrderResponse`` that will provide the Order id if successful.
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     class func sell(asset: AssetModel, sellToken: AssetModel, fees: [FeeEntry], signer: Signer, starkSigner: StarkSigner, ordersAPI: OrdersAPI.Type = OrdersAPI.self) async throws -> CreateOrderResponse {
         let address = try await signer.getAddress()
         let orderResponse = try await getSignableOrder(asset: asset, sellToken: sellToken, address: address, fees: fees, api: ordersAPI)

--- a/Sources/ImmutableXCore/Workflows/TransferWorkflow.swift
+++ b/Sources/ImmutableXCore/Workflows/TransferWorkflow.swift
@@ -9,7 +9,7 @@ class TransferWorkflow {
     ///     - signer: represents the users L1 wallet to get the address
     ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
     /// - Returns: ``CreateTransferResponse`` that will provide the transfer id if successful.
-    /// - Throws: A variation of ``ImmutableXCoreError``
+    /// - Throws: A variation of ``ImmutableXError``
     class func transfer(token: AssetModel, recipientAddress: String, signer: Signer, starkSigner: StarkSigner, transfersAPI: TransfersAPI.Type = TransfersAPI.self) async throws -> CreateTransferResponse {
         let address = try await signer.getAddress()
         let response = try await getSignableTransfer(address: address, token: token, recipientAddress: recipientAddress, api: transfersAPI)

--- a/Sources/ImmutableXCore/Workflows/Workflow.swift
+++ b/Sources/ImmutableXCore/Workflows/Workflow.swift
@@ -13,16 +13,16 @@ struct WorkflowSignatures {
 }
 
 enum Workflow {
-    /// A helper that parses any non-``ImmutableXCoreError`` into ``ImmutableXCoreError.apiFailure(caller:error:)``
+    /// A helper that parses any non-``ImmutableXError`` into ``ImmutableXError.apiFailure(caller:error:)``
     static func mapAPIErrors<T>(caller: String, apiCall: () async throws -> T) async throws -> T {
         do {
             return try await apiCall()
         } catch {
-            if error is ImmutableXCoreError {
+            if error is ImmutableXError {
                 throw error
             }
 
-            throw ImmutableXCoreError.apiFailure(caller: caller, error: error)
+            throw ImmutableXError.apiFailure(caller: caller, error: error)
         }
     }
 }

--- a/Tests/ImmutableXCoreTests/Config/ImmutableXBaseTests.swift
+++ b/Tests/ImmutableXCoreTests/Config/ImmutableXBaseTests.swift
@@ -4,16 +4,16 @@ import XCTest
 final class ImmutableXBaseTests: XCTestCase {
     func testPublicApiUrl() async throws {
         XCTAssertEqual(ImmutableXBase.production.publicApiUrl, "https://api.x.immutable.com")
-        XCTAssertEqual(ImmutableXBase.ropsten.publicApiUrl, "https://api.ropsten.x.immutable.com")
+        XCTAssertEqual(ImmutableXBase.sandbox.publicApiUrl, "https://api.sandbox.x.immutable.com")
     }
 
     func testMoonpayApiKey() async throws {
         XCTAssertEqual(ImmutableXBase.production.moonpayApiKey, "pk_live_lgGxv3WyWjnWff44ch4gmolN0953")
-        XCTAssertEqual(ImmutableXBase.ropsten.moonpayApiKey, "pk_test_nGdsu1IBkjiFzmEvN8ddf4gM9GNy5Sgz")
+        XCTAssertEqual(ImmutableXBase.sandbox.moonpayApiKey, "pk_test_nGdsu1IBkjiFzmEvN8ddf4gM9GNy5Sgz")
     }
 
     func testBuyCryptoUrl() async throws {
         XCTAssertEqual(ImmutableXBase.production.buyCryptoUrl, "https://buy.moonpay.io")
-        XCTAssertEqual(ImmutableXBase.ropsten.buyCryptoUrl, "https://buy-staging.moonpay.io")
+        XCTAssertEqual(ImmutableXBase.sandbox.buyCryptoUrl, "https://buy-staging.moonpay.io")
     }
 }

--- a/Tests/ImmutableXCoreTests/Crypto/BIP32/BIP32KeyTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/BIP32/BIP32KeyTests.swift
@@ -8,7 +8,7 @@ final class BIP32KeyTests: XCTestCase {
     func testDeriveThrowsForInvalidPath() throws {
         let path = "m/purpose'/layer'/application'/ethAddress1'/ethAddress2'/1"
         XCTAssertThrowsError(try BIP32Key.derive(seed: seed, path: path), "unhashed/formatted path") { error in
-            XCTAssertTrue(error is ImmutableXCoreError)
+            XCTAssertTrue(error is ImmutableXError)
         }
     }
 

--- a/Tests/ImmutableXCoreTests/Crypto/Keys/PrivateKeyTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/Keys/PrivateKeyTests.swift
@@ -6,11 +6,11 @@ final class PrivateKeyTests: XCTestCase {
     func testInitNumber() throws {
         let biggerNumber = StarkCurve.N + 1
         XCTAssertThrowsError(try PrivateKey(number: biggerNumber), "Should throw if number is not in the StarkCurve.N range") { error in
-            XCTAssertTrue(error is ImmutableXCoreError)
+            XCTAssertTrue(error is ImmutableXError)
         }
 
         XCTAssertThrowsError(try PrivateKey(number: BigInt.zero), "Should throw if number is smaller than 1") { error in
-            XCTAssertTrue(error is ImmutableXCoreError)
+            XCTAssertTrue(error is ImmutableXError)
         }
 
         let inRangeNumber = StarkCurve.N - 1
@@ -21,7 +21,7 @@ final class PrivateKeyTests: XCTestCase {
 
     func testInitHex() throws {
         XCTAssertThrowsError(try PrivateKey(hex: "invalid"), "Should throw if hex can't be represented as a BigInt") { error in
-            XCTAssertTrue(error is ImmutableXCoreError)
+            XCTAssertTrue(error is ImmutableXError)
         }
 
         let inRangeNumber = StarkCurve.N - 1

--- a/Tests/ImmutableXCoreTests/Crypto/Stark/StarkKeyTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/Stark/StarkKeyTests.swift
@@ -57,7 +57,7 @@ final class StarkKeyTests: XCTestCase {
     func testGenerateFromSignerClosureFailure() {
         let signer = SignerMock()
         signer.getAddressReturnValue = "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f"
-        signer.signMessageThrowableError = ImmutableXCoreError.invalidKeyData
+        signer.signMessageThrowableError = ImmutableXError.invalidKeyData
 
         let expectation = XCTestExpectation(description: "testGenerateFromSignerClosure")
 
@@ -86,13 +86,13 @@ final class StarkKeyTests: XCTestCase {
     func testGenerateFromSignerAsyncFailure() async throws {
         let signer = SignerMock()
         signer.getAddressReturnValue = "0xa76e3eeb2f7143165618ab8feaabcd395b6fac7f"
-        signer.signMessageThrowableError = ImmutableXCoreError.invalidKeyData
+        signer.signMessageThrowableError = ImmutableXError.invalidKeyData
 
         do {
             _ = try await StarkKey.generateKeyPair(from: signer)
             XCTFail("Expected to throw while awaiting, but succeeded")
         } catch {
-            XCTAssertTrue(error is ImmutableXCoreError)
+            XCTAssertTrue(error is ImmutableXError)
         }
     }
 }

--- a/Tests/ImmutableXCoreTests/Custom APIs/ExchangesAPITests.swift
+++ b/Tests/ImmutableXCoreTests/Custom APIs/ExchangesAPITests.swift
@@ -7,7 +7,7 @@ final class ExchangesAPITests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        ImmutableXCore.shared = coreStub1
+        ImmutableX.shared = coreStub1
     }
 
     func testGetTransactionIdSuccessful() async throws {

--- a/Tests/ImmutableXCoreTests/Custom APIs/MoonpayAPITests.swift
+++ b/Tests/ImmutableXCoreTests/Custom APIs/MoonpayAPITests.swift
@@ -17,7 +17,7 @@ final class MoonpayAPITests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        ImmutableXCore.shared = coreStub1
+        ImmutableX.shared = coreStub1
         builderMock.mock(.success(Response(response: HTTPURLResponse(), body: signedMoonpayResponseStub1)))
     }
 

--- a/Tests/ImmutableXCoreTests/ImmutableXTests.swift
+++ b/Tests/ImmutableXCoreTests/ImmutableXTests.swift
@@ -51,8 +51,8 @@ final class ImmutableXTests: XCTestCase {
     }
 
     func testInitialize() {
-        ImmutableX.initialize(base: .ropsten, logLevel: .calls(including: [.requestBody]))
-        XCTAssertEqual(ImmutableX.shared.base, .ropsten)
+        ImmutableX.initialize(base: .sandbox, logLevel: .calls(including: [.requestBody]))
+        XCTAssertEqual(ImmutableX.shared.base, .sandbox)
 
         if case .calls(including: [.requestBody]) = ImmutableX.shared.logLevel {
             // success

--- a/Tests/ImmutableXCoreTests/ImmutableXTests.swift
+++ b/Tests/ImmutableXCoreTests/ImmutableXTests.swift
@@ -1,7 +1,7 @@
 @testable import ImmutableXCore
 import XCTest
 
-final class ImmutableXCoreTests: XCTestCase {
+final class ImmutableXTests: XCTestCase {
     let buyWorkflow = BuyWorkflowMock.self
     let sellWorkflow = SellWorkflowMock.self
     let cancelOrderWorkflow = CancelOrderWorkflowMock.self
@@ -9,7 +9,7 @@ final class ImmutableXCoreTests: XCTestCase {
     let registerWorkflowMock = RegisterWorkflowMock.self
     let buyCryptoWorkflowMock = BuyCryptoWorkflowMock.self
 
-    lazy var core = ImmutableXCore(buyWorkflow: buyWorkflow, sellWorkflow: sellWorkflow, cancelOrderWorkflow: cancelOrderWorkflow, transferWorkflow: transferWorkflowMock, registerWorkflow: registerWorkflowMock, buyCryptoWorkflow: buyCryptoWorkflowMock)
+    lazy var core = ImmutableX(buyWorkflow: buyWorkflow, sellWorkflow: sellWorkflow, cancelOrderWorkflow: cancelOrderWorkflow, transferWorkflow: transferWorkflowMock, registerWorkflow: registerWorkflowMock, buyCryptoWorkflow: buyCryptoWorkflowMock)
 
     override func setUp() {
         super.setUp()
@@ -19,7 +19,7 @@ final class ImmutableXCoreTests: XCTestCase {
         transferWorkflowMock.resetMock()
         registerWorkflowMock.resetMock()
         buyCryptoWorkflowMock.resetMock()
-        ImmutableXCore.initialize()
+        ImmutableX.initialize()
 
         let buyCompanion = BuyWorkflowCompanion()
         buyCompanion.returnValue = createTradeResponseStub1
@@ -47,14 +47,14 @@ final class ImmutableXCoreTests: XCTestCase {
     }
 
     func testSdkVersion() {
-        XCTAssertEqual(ImmutableXCore.shared.sdkVersion, "0.3.1")
+        XCTAssertEqual(ImmutableX.shared.sdkVersion, "0.3.1")
     }
 
     func testInitialize() {
-        ImmutableXCore.initialize(base: .ropsten, logLevel: .calls(including: [.requestBody]))
-        XCTAssertEqual(ImmutableXCore.shared.base, .ropsten)
+        ImmutableX.initialize(base: .ropsten, logLevel: .calls(including: [.requestBody]))
+        XCTAssertEqual(ImmutableX.shared.base, .ropsten)
 
-        if case .calls(including: [.requestBody]) = ImmutableXCore.shared.logLevel {
+        if case .calls(including: [.requestBody]) = ImmutableX.shared.logLevel {
             // success
         } else {
             XCTFail("Log level should have matched the initialize's method")

--- a/Tests/ImmutableXCoreTests/ImmutableXTests.swift
+++ b/Tests/ImmutableXCoreTests/ImmutableXTests.swift
@@ -47,7 +47,7 @@ final class ImmutableXTests: XCTestCase {
     }
 
     func testSdkVersion() {
-        XCTAssertEqual(ImmutableX.shared.sdkVersion, "0.3.1")
+        XCTAssertEqual(ImmutableX.shared.sdkVersion, "0.4.0")
     }
 
     func testInitialize() {

--- a/Tests/ImmutableXCoreTests/Mocks/Stubs/Models.swift
+++ b/Tests/ImmutableXCoreTests/Mocks/Stubs/Models.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import ImmutableXCore
 
-let coreStub1 = ImmutableX(base: .ropsten, buyWorkflow: BuyWorkflowMock.self, sellWorkflow: SellWorkflowMock.self, cancelOrderWorkflow: CancelOrderWorkflowMock.self, transferWorkflow: TransferWorkflowMock.self, registerWorkflow: RegisterWorkflowMock.self)
+let coreStub1 = ImmutableX(base: .sandbox, buyWorkflow: BuyWorkflowMock.self, sellWorkflow: SellWorkflowMock.self, cancelOrderWorkflow: CancelOrderWorkflowMock.self, transferWorkflow: TransferWorkflowMock.self, registerWorkflow: RegisterWorkflowMock.self)
 
 let tokenETHStub1 = Token(
     data: TokenData(

--- a/Tests/ImmutableXCoreTests/Mocks/Stubs/Models.swift
+++ b/Tests/ImmutableXCoreTests/Mocks/Stubs/Models.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import ImmutableXCore
 
-let coreStub1 = ImmutableXCore(base: .ropsten, buyWorkflow: BuyWorkflowMock.self, sellWorkflow: SellWorkflowMock.self, cancelOrderWorkflow: CancelOrderWorkflowMock.self, transferWorkflow: TransferWorkflowMock.self, registerWorkflow: RegisterWorkflowMock.self)
+let coreStub1 = ImmutableX(base: .ropsten, buyWorkflow: BuyWorkflowMock.self, sellWorkflow: SellWorkflowMock.self, cancelOrderWorkflow: CancelOrderWorkflowMock.self, transferWorkflow: TransferWorkflowMock.self, registerWorkflow: RegisterWorkflowMock.self)
 
 let tokenETHStub1 = Token(
     data: TokenData(

--- a/Tests/ImmutableXCoreTests/Mocks/Workflows/BuyCryptoWorkflowMock.swift
+++ b/Tests/ImmutableXCoreTests/Mocks/Workflows/BuyCryptoWorkflowMock.swift
@@ -18,7 +18,7 @@ class BuyCryptoWorkflowMock: BuyCryptoWorkflow {
         companion = nil
     }
 
-    override class func buyCryptoURL(colorCodeHex: String = "#00818e", signer: Signer, base: ImmutableXBase = ImmutableXCore.shared.base, moonpayAPI: MoonpayAPI = MoonpayAPI(), exchangesAPI: ExchangesAPI = ExchangesAPI(), usersAPI: UsersAPI.Type = UsersAPI.self) async throws -> String {
+    override class func buyCryptoURL(colorCodeHex: String = "#00818e", signer: Signer, base: ImmutableXBase = ImmutableX.shared.base, moonpayAPI: MoonpayAPI = MoonpayAPI(), exchangesAPI: ExchangesAPI = ExchangesAPI(), usersAPI: UsersAPI.Type = UsersAPI.self) async throws -> String {
         let companion = companion!
         companion.callsCount += 1
 

--- a/Tests/ImmutableXCoreTests/Workflows/BuyCryptoWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/BuyCryptoWorkflowTests.swift
@@ -9,7 +9,7 @@ final class BuyCryptoWorkflowTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        ImmutableXCore.shared = coreStub1
+        ImmutableX.shared = coreStub1
 
         usersAPI.resetMock()
         exchangesAPI.resetMock()

--- a/Tests/ImmutableXCoreTests/Workflows/BuyCryptoWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/BuyCryptoWorkflowTests.swift
@@ -36,7 +36,7 @@ final class BuyCryptoWorkflowTests: XCTestCase {
         let response = try await BuyCryptoWorkflow.buyCryptoURL(
             colorCodeHex: "#000000",
             signer: SignerMock(),
-            base: .ropsten,
+            base: .sandbox,
             moonpayAPI: moonpayAPI,
             exchangesAPI: exchangesAPI,
             usersAPI: usersAPI
@@ -54,7 +54,7 @@ final class BuyCryptoWorkflowTests: XCTestCase {
             _ = try await BuyCryptoWorkflow.buyCryptoURL(
                 colorCodeHex: "#000000",
                 signer: SignerMock(),
-                base: .ropsten,
+                base: .sandbox,
                 moonpayAPI: self.moonpayAPI,
                 exchangesAPI: self.exchangesAPI,
                 usersAPI: self.usersAPI
@@ -71,7 +71,7 @@ final class BuyCryptoWorkflowTests: XCTestCase {
             _ = try await BuyCryptoWorkflow.buyCryptoURL(
                 colorCodeHex: "#000000",
                 signer: SignerMock(),
-                base: .ropsten,
+                base: .sandbox,
                 moonpayAPI: self.moonpayAPI,
                 exchangesAPI: self.exchangesAPI,
                 usersAPI: self.usersAPI
@@ -88,7 +88,7 @@ final class BuyCryptoWorkflowTests: XCTestCase {
             _ = try await BuyCryptoWorkflow.buyCryptoURL(
                 colorCodeHex: "#000000",
                 signer: SignerMock(),
-                base: .ropsten,
+                base: .sandbox,
                 moonpayAPI: self.moonpayAPI,
                 exchangesAPI: self.exchangesAPI,
                 usersAPI: self.usersAPI
@@ -105,7 +105,7 @@ final class BuyCryptoWorkflowTests: XCTestCase {
             _ = try await BuyCryptoWorkflow.buyCryptoURL(
                 colorCodeHex: "#000000",
                 signer: SignerMock(),
-                base: .ropsten,
+                base: .sandbox,
                 moonpayAPI: self.moonpayAPI,
                 exchangesAPI: self.exchangesAPI,
                 usersAPI: self.usersAPI

--- a/Tests/ImmutableXCoreTests/Workflows/RegisterWorkflowTests.swift
+++ b/Tests/ImmutableXCoreTests/Workflows/RegisterWorkflowTests.swift
@@ -55,7 +55,7 @@ final class RegisterWorkflowTests: XCTestCase {
             _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: self.usersAPI)
         }
 
-        XCTAssertTrue(error is ImmutableXCoreError)
+        XCTAssertTrue(error is ImmutableXError)
         XCTAssertEqual(usersAPI.getUsersCompanion?.callsCount, 1)
         XCTAssertEqual(usersAPI.getSignableCompanion?.callsCount, 0)
         XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
@@ -70,7 +70,7 @@ final class RegisterWorkflowTests: XCTestCase {
             _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: self.usersAPI)
         }
 
-        XCTAssertTrue(error is ImmutableXCoreError)
+        XCTAssertTrue(error is ImmutableXError)
         XCTAssertEqual(usersAPI.getUsersCompanion?.callsCount, 1)
         XCTAssertEqual(usersAPI.getSignableCompanion?.callsCount, 1)
         XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 0)
@@ -85,7 +85,7 @@ final class RegisterWorkflowTests: XCTestCase {
             _ = try await RegisterWorkflow.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock(), usersAPI: self.usersAPI)
         }
 
-        XCTAssertTrue(error is ImmutableXCoreError)
+        XCTAssertTrue(error is ImmutableXError)
         XCTAssertEqual(usersAPI.getUsersCompanion?.callsCount, 1)
         XCTAssertEqual(usersAPI.getSignableCompanion?.callsCount, 1)
         XCTAssertEqual(usersAPI.registerCompanion?.callsCount, 1)

--- a/openapi.json
+++ b/openapi.json
@@ -11,7 +11,7 @@
     },
     "version": "0.1"
   },
-  "host": "api.ropsten.x.immutable.com",
+  "host": "api.sandbox.x.immutable.com",
   "basePath": "/",
   "paths": {
     "/v1/assets": {


### PR DESCRIPTION
- rename ImmutableXCore to ImmutableX
This follows the new spec for the core SDKs that will come to swift shortly.

- re-include macos as a Cocoapods target
The Core SDK is generic enough that it should work on macOS. It had
accidentally been removed on 0.3.1.

- replace ropsten environment for sandbox
Ropsten has been deprecated and won't work anymore. Sandbox is the preferred testing environment.

- bump SDK version to 0.4.0