### PR TITLE
refactor!: remove Closure based APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ for soon-to-be removed features.
 ### Removed
 
 - (Breaking): all clients have been removed in favour of direct methods in the ImmutableX instance.
+- (Breaking): removed closure based APIs from ImmutableX instance.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ let collections = try await CollectionsAPI.listCollections(
 
 View the [OpenAPI spec](openapi.json) for a full list of API requests available in the Core SDK.
 
-NOTE: Closure based APIs are also available.
-
 ### Wallet Connection
 
 In order to use any workflow functions, you will need to pass in the connected wallet provider. This means you will need to implement your own Wallet L1 [Signer](https://github.com/immutable/imx-core-sdk-swift/blob/main/Sources/ImmutableXCore/Signer.swift) and L2 [StarkSigner](https://github.com/immutable/imx-core-sdk-swift/blob/main/Sources/ImmutableXCore/Signer.swift).

--- a/Sources/ImmutableXCore/ImmutableX.swift
+++ b/Sources/ImmutableXCore/ImmutableX.swift
@@ -66,28 +66,6 @@ public struct ImmutableX {
         try await buyWorkflow.buy(orderId: orderId, fees: fees, signer: signer, starkSigner: starkSigner)
     }
 
-    /// This is a utility function that will chain the necessary calls to buy an existing order.
-    ///
-    ///  - Parameters:
-    ///     - orderId: the id of an existing order to be bought
-    ///     - fees: taker fees information to be used in the buy order.
-    ///     - signer: represents the users L1 wallet to get the address
-    ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
-    /// - Returns: a ``CreateTradeResponse`` tthat will provide the Trade id if successful
-    ///  or an ``ImmutableXError`` error through the `onCompletion` callback
-    ///
-    /// - Note: `onCompletion` is executed on the Main Thread
-    public func buy(orderId: String, fees: [FeeEntry] = [], signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CreateTradeResponse, ImmutableXError>) -> Void) {
-        Task { @MainActor in
-            do {
-                let response = try await buyWorkflow.buy(orderId: orderId, fees: fees, signer: signer, starkSigner: starkSigner)
-                onCompletion(.success(response))
-            } catch {
-                onCompletion(.failure(error.asImmutableXError))
-            }
-        }
-    }
-
     /// This is a utility function that will chain the necessary calls to sell an asset.
     ///
     /// - Parameters:
@@ -102,29 +80,6 @@ public struct ImmutableX {
         try await sellWorkflow.sell(asset: asset, sellToken: sellToken, fees: fees, signer: signer, starkSigner: starkSigner)
     }
 
-    /// This is a utility function that will chain the necessary calls to sell an asset.
-    ///
-    /// - Parameters:
-    ///     - asset: the asset to sell
-    ///     - sellToken: the type of token and how much of it to sell the asset for
-    ///     - fees: maker fees information to be used in the sell order.
-    ///     - signer: represents the users L1 wallet to get the address
-    ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
-    /// - Returns: a ``CreateOrderResponse`` that will provide the Order id if successful
-    ///  or an ``ImmutableXError`` error through the `onCompletion` callback
-    ///
-    /// - Note: `onCompletion` is executed on the Main Thread
-    public func sell(asset: AssetModel, sellToken: AssetModel, fees: [FeeEntry], signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CreateOrderResponse, ImmutableXError>) -> Void) {
-        Task { @MainActor in
-            do {
-                let response = try await sellWorkflow.sell(asset: asset, sellToken: sellToken, fees: fees, signer: signer, starkSigner: starkSigner)
-                onCompletion(.success(response))
-            } catch {
-                onCompletion(.failure(error.asImmutableXError))
-            }
-        }
-    }
-
     /// This is a utility function that will chain the necessary calls to cancel an existing order.
     ///
     /// - Parameters:
@@ -135,27 +90,6 @@ public struct ImmutableX {
     /// - Throws: A variation of ``ImmutableXError``
     public func cancelOrder(orderId: String, signer: Signer, starkSigner: StarkSigner) async throws -> CancelOrderResponse {
         try await cancelOrderWorkflow.cancel(orderId: orderId, signer: signer, starkSigner: starkSigner)
-    }
-
-    /// This is a utility function that will chain the necessary calls to cancel an existing order.
-    ///
-    /// - Parameters:
-    ///     - orderId: the id of an existing order to be bought
-    ///     - signer: represents the users L1 wallet to get the address
-    ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
-    /// - Returns: a ``CancelOrderResponse`` that will provide the cancelled Order id if successful
-    ///  or an ``ImmutableXError`` error through the `onCompletion` callback
-    ///
-    /// - Note: `onCompletion` is executed on the Main Thread
-    public func cancelOrder(orderId: String, signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CancelOrderResponse, ImmutableXError>) -> Void) {
-        Task { @MainActor in
-            do {
-                let response = try await cancelOrderWorkflow.cancel(orderId: orderId, signer: signer, starkSigner: starkSigner)
-                onCompletion(.success(response))
-            } catch {
-                onCompletion(.failure(error.asImmutableXError))
-            }
-        }
     }
 
     /// This is a utility function that will chain the necessary calls to transfer a token.
@@ -171,28 +105,6 @@ public struct ImmutableX {
         try await transferWorkflow.transfer(token: token, recipientAddress: recipientAddress, signer: signer, starkSigner: starkSigner)
     }
 
-    /// This is a utility function that will chain the necessary calls to transfer a token.
-    ///
-    /// - Parameters:
-    ///     - token: to be transferred (ETH, ERC20, or ERC721)
-    ///     - recipientAddress: of the wallet that will receive the token
-    ///     - signer: represents the users L1 wallet to get the address
-    ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
-    /// - Returns: a ``CreateTransferResponse`` that will provide the transfer id if successful
-    ///  or an ``ImmutableXError`` error through the `onCompletion` callback
-    ///
-    /// - Note: `onCompletion` is executed on the Main Thread
-    public func transfer(token: AssetModel, recipientAddress: String, signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<CreateTransferResponse, ImmutableXError>) -> Void) {
-        Task { @MainActor in
-            do {
-                let response = try await transferWorkflow.transfer(token: token, recipientAddress: recipientAddress, signer: signer, starkSigner: starkSigner)
-                onCompletion(.success(response))
-            } catch {
-                onCompletion(.failure(error.asImmutableXError))
-            }
-        }
-    }
-
     /// This is a utility function that will register a user to Immutable X if they aren't already
     ///
     /// - Parameters:
@@ -202,26 +114,6 @@ public struct ImmutableX {
     /// - Throws: A variation of ``ImmutableXError``
     public func registerOffchain(signer: Signer, starkSigner: StarkSigner) async throws {
         _ = try await registerWorkflow.registerOffchain(signer: signer, starkSigner: starkSigner)
-    }
-
-    /// This is a utility function that will register a user to Immutable X if they aren't already
-    ///
-    /// - Parameters:
-    ///     - signer: represents the users L1 wallet to get the address
-    ///     - starkSigner: represents the users L2 wallet used to sign and verify the L2 transaction
-    /// - Returns: `Void` if user is registered or an ``ImmutableXError`` error through
-    /// the `onCompletion` callback
-    ///
-    /// - Note: `onCompletion` is executed on the Main Thread
-    public func registerOffchain(signer: Signer, starkSigner: StarkSigner, onCompletion: @escaping (Result<Void, ImmutableXError>) -> Void) {
-        Task { @MainActor in
-            do {
-                _ = try await registerWorkflow.registerOffchain(signer: signer, starkSigner: starkSigner)
-                onCompletion(.success(()))
-            } catch {
-                onCompletion(.failure(error.asImmutableXError))
-            }
-        }
     }
 
     /// Gets a URL to MoonPay that provides a service for buying crypto directly on Immutable in exchange for fiat.
@@ -234,26 +126,5 @@ public struct ImmutableX {
     /// - Throws: A variation of ``ImmutableXError``
     public func buyCryptoURL(colorCodeHex: String = "#00818e", signer: Signer) async throws -> String {
         try await buyCryptoWorkflow.buyCryptoURL(colorCodeHex: colorCodeHex, signer: signer)
-    }
-
-    /// Gets a URL to MoonPay that provides a service for buying crypto directly on Immutable in exchange for fiat.
-    ///
-    /// - Parameters:
-    ///     - colorCodeHex: the color code in hex (e.g. #00818e) for the Moon pay widget main color.
-    ///     It is used for buttons, links and highlighted text. Defaults to `#00818e`
-    ///     - signer: represents the users L1 wallet to get the address
-    /// - Returns: a website URL string to be used to launch a WebView or Browser to buy crypto if successful
-    /// or an ``ImmutableXError`` error through the `onCompletion` callback
-    ///
-    /// - Note: `onCompletion` is executed on the Main Thread
-    public func buyCryptoURL(colorCodeHex: String = "#00818e", signer: Signer, onCompletion: @escaping (Result<String, ImmutableXError>) -> Void) {
-        Task { @MainActor in
-            do {
-                let response = try await buyCryptoWorkflow.buyCryptoURL(colorCodeHex: colorCodeHex, signer: signer)
-                onCompletion(.success(response))
-            } catch {
-                onCompletion(.failure(error.asImmutableXError))
-            }
-        }
     }
 }

--- a/Tests/ImmutableXCoreTests/ImmutableXTests.swift
+++ b/Tests/ImmutableXCoreTests/ImmutableXTests.swift
@@ -78,41 +78,6 @@ final class ImmutableXTests: XCTestCase {
         }
     }
 
-    func testBuyFlowSuccessClosure() {
-        let expectation = expectation(description: "testBuyFlowSuccessClosure")
-
-        core.buy(orderId: "1", fees: [feeEntryStub1], signer: SignerMock(), starkSigner: StarkSignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case let .success(response):
-                XCTAssertEqual(response, createTradeResponseStub1)
-            case .failure:
-                XCTFail("Should not have failed")
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
-    }
-
-    func testBuyFlowFailureClosure() {
-        let buyCompanion = BuyWorkflowCompanion()
-        buyCompanion.throwableError = DummyError.something
-        buyWorkflow.mock(buyCompanion, id: "1")
-
-        let expectation = expectation(description: "testBuyFlowFailureClosure")
-        core.buy(orderId: "1", fees: [feeEntryStub1], signer: SignerMock(), starkSigner: StarkSignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case .success:
-                XCTFail("Should not have succeeded")
-            case .failure:
-                break
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
-    }
-
     // MARK: - Sell
 
     func testSellFlowSuccessAsync() async throws {
@@ -128,41 +93,6 @@ final class ImmutableXTests: XCTestCase {
         await XCTAssertThrowsErrorAsync {
             _ = try await self.core.sell(asset: erc721AssetStub1, sellToken: erc20AssetStub1, fees: [], signer: SignerMock(), starkSigner: StarkSignerMock())
         }
-    }
-
-    func testSellFlowSuccessClosure() {
-        let expectation = expectation(description: "testSellFlowSuccessClosure")
-
-        core.sell(asset: erc721AssetStub1, sellToken: erc20AssetStub1, fees: [], signer: SignerMock(), starkSigner: StarkSignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case let .success(response):
-                XCTAssertEqual(response, createOrderResponseStub1)
-            case .failure:
-                XCTFail("Should not have failed")
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
-    }
-
-    func testSellFlowFailureClosure() {
-        let sellCompanion = SellWorkflowCompanion()
-        sellCompanion.throwableError = DummyError.something
-        sellWorkflow.mock(sellCompanion)
-
-        let expectation = expectation(description: "testSellFlowFailureClosure")
-        core.sell(asset: erc721AssetStub1, sellToken: erc20AssetStub1, fees: [], signer: SignerMock(), starkSigner: StarkSignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case .success:
-                XCTFail("Should not have succeeded")
-            case .failure:
-                break
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
     }
 
     // MARK: - Cancel
@@ -182,41 +112,6 @@ final class ImmutableXTests: XCTestCase {
         }
     }
 
-    func testCancelOrderFlowSuccessClosure() {
-        let expectation = expectation(description: "testCancelOrderFlowSuccessClosure")
-
-        core.cancelOrder(orderId: "1", signer: SignerMock(), starkSigner: StarkSignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case let .success(response):
-                XCTAssertEqual(response, cancelOrderResponseStub1)
-            case .failure:
-                XCTFail("Should not have failed")
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
-    }
-
-    func testCancelOrderFlowFailureClosure() {
-        let cancelOrderCompanion = CancelOrderWorkflowCompanion()
-        cancelOrderCompanion.throwableError = DummyError.something
-        cancelOrderWorkflow.mock(cancelOrderCompanion, id: "1")
-
-        let expectation = expectation(description: "testCancelOrderFlowFailureClosure")
-        core.cancelOrder(orderId: "1", signer: SignerMock(), starkSigner: StarkSignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case .success:
-                XCTFail("Should not have succeeded")
-            case .failure:
-                break
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
-    }
-
     // MARK: - Transfer
 
     func testTransferFlowSuccessAsync() async throws {
@@ -232,42 +127,6 @@ final class ImmutableXTests: XCTestCase {
         await XCTAssertThrowsErrorAsync {
             _ = try await self.core.transfer(token: ETHAsset(quantity: "10"), recipientAddress: "address", signer: SignerMock(), starkSigner: StarkSignerMock())
         }
-    }
-
-    func testTransferFlowSuccessClosure() {
-        let expectation = expectation(description: "testTransferFlowSuccessClosure")
-
-        core.transfer(token: ETHAsset(quantity: "10"), recipientAddress: "address", signer: SignerMock(), starkSigner: StarkSignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case let .success(response):
-                XCTAssertEqual(response, createTransferResponseStub1)
-            case .failure:
-                XCTFail("Should not have failed")
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
-    }
-
-    func testTransferFlowFailureClosure() {
-        let transferCompanion = TransferWorkflowCompanion()
-        transferCompanion.throwableError = DummyError.something
-        transferWorkflowMock.mock(transferCompanion)
-
-        let expectation = expectation(description: "testTransferFlowFailureClosure")
-
-        core.transfer(token: ETHAsset(quantity: "10"), recipientAddress: "address", signer: SignerMock(), starkSigner: StarkSignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case .success:
-                XCTFail("Should not have succeeded")
-            case .failure:
-                break
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
     }
 
     // MARK: - Register
@@ -287,42 +146,6 @@ final class ImmutableXTests: XCTestCase {
         }
     }
 
-    func testRegisterFlowSuccessClosure() {
-        let expectation = expectation(description: "testRegisterFlowSuccessClosure")
-
-        core.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock()) { [weak self] result in
-            expectation.fulfill()
-            switch result {
-            case .success:
-                XCTAssertEqual(self?.registerWorkflowMock.companion.callsCount, 1)
-            case .failure:
-                XCTFail("Should not have failed")
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
-    }
-
-    func testRegisterFlowFailureClosure() {
-        let registerCompanion = RegisterWorkflowCompanion()
-        registerCompanion.throwableError = DummyError.something
-        registerWorkflowMock.mock(registerCompanion)
-
-        let expectation = expectation(description: "testRegisterFlowFailureClosure")
-
-        core.registerOffchain(signer: SignerMock(), starkSigner: StarkSignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case .success:
-                XCTFail("Should not have succeeded")
-            case .failure:
-                break
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
-    }
-
     // MARK: - Buy Crypto
 
     func testBuyCryptoFlowSuccessAsync() async throws {
@@ -338,41 +161,5 @@ final class ImmutableXTests: XCTestCase {
         await XCTAssertThrowsErrorAsync {
             _ = try await self.core.buyCryptoURL(signer: SignerMock())
         }
-    }
-
-    func testBuyCryptoFlowSuccessClosure() {
-        let expectation = expectation(description: "testBuyCryptoFlowSuccessClosure")
-
-        core.buyCryptoURL(signer: SignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case let .success(url):
-                XCTAssertEqual(url, "expected url")
-            case .failure:
-                XCTFail("Should not have failed")
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
-    }
-
-    func testBuyCryptoFlowFailureClosure() {
-        let buyCryptoCompanion = BuyCryptoWorkflowCompanion()
-        buyCryptoCompanion.throwableError = DummyError.something
-        buyCryptoWorkflowMock.mock(buyCryptoCompanion)
-
-        let expectation = expectation(description: "testBuyCryptoFlowFailureClosure")
-
-        core.buyCryptoURL(signer: SignerMock()) { result in
-            expectation.fulfill()
-            switch result {
-            case .success:
-                XCTFail("Should not have succeeded")
-            case .failure:
-                break
-            }
-        }
-
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 30), .completed)
     }
 }


### PR DESCRIPTION
These APIs have a cost to be maintained and can be easily done by partners if they do no wish to use async await.