### PR TITLE
chore: update OpenAPIGenerator templates to v6.2.1

### DIFF
--- a/.openapi-generator/templates/swift5/APIs.mustache
+++ b/.openapi-generator/templates/swift5/APIs.mustache
@@ -40,17 +40,19 @@ import Vapor
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let method: String
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let URLString: String
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let requestTask: RequestTask = RequestTask()
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let requiresAuthentication: Bool
 
     /// Optional block to obtain a reference to the request's progress instance when available.{{#useURLSession}}
     /// With the URLSession http client the request's progress only works on iOS 11.0, macOS 10.13, macCatalyst 13.0, tvOS 11.0, watchOS 4.0.
     /// If you need to get the request's progress in older OS versions, please use Alamofire http client.{{/useURLSession}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var onProgressReady: ((Progress) -> Void)?
 
-    required {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:]) {
+    required {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool) {
         self.method = method
         self.URLString = URLString
         self.parameters = parameters
         self.headers = headers
+        self.requiresAuthentication = requiresAuthentication
 
         addHeaders({{projectName}}API.customHeaders)
     }

--- a/.openapi-generator/templates/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/.openapi-generator/templates/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -55,8 +55,8 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
      */
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var taskCompletionShouldRetry: ((Data?, URLResponse?, Error?, @escaping (Bool) -> Void) -> Void)?
 
-    required {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:]) {
-        super.init(method: method, URLString: URLString, parameters: parameters, headers: headers)
+    required {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool) {
+        super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication)
     }
 
     /**

--- a/Sources/ImmutableXCore/Custom APIs/ExchangesAPI.swift
+++ b/Sources/ImmutableXCore/Custom APIs/ExchangesAPI.swift
@@ -61,7 +61,8 @@ class ExchangesAPI {
         let requestBuilder = requestBuilderType.init(
             method: "POST",
             URLString: URLString,
-            parameters: parameters
+            parameters: parameters,
+            requiresAuthentication: false
         )
 
         return try await requestBuilder.execute()
@@ -75,7 +76,8 @@ class ExchangesAPI {
         let requestBuilder = requestBuilderType.init(
             method: "GET",
             URLString: URLString,
-            parameters: nil
+            parameters: nil,
+            requiresAuthentication: false
         )
 
         let response = try await requestBuilder.execute()

--- a/Sources/ImmutableXCore/Custom APIs/MoonpayAPI.swift
+++ b/Sources/ImmutableXCore/Custom APIs/MoonpayAPI.swift
@@ -78,7 +78,8 @@ class MoonpayAPI {
         let requestBuilder = requestBuilderType.init(
             method: "POST",
             URLString: URLString,
-            parameters: parameters
+            parameters: parameters,
+            requiresAuthentication: false
         )
 
         let response = try await requestBuilder.execute()

--- a/Sources/ImmutableXCore/Generated/APIs.swift
+++ b/Sources/ImmutableXCore/Generated/APIs.swift
@@ -31,17 +31,19 @@ internal class RequestBuilder<T> {
     internal let method: String
     internal let URLString: String
     internal let requestTask: RequestTask = RequestTask()
+    internal let requiresAuthentication: Bool
 
     /// Optional block to obtain a reference to the request's progress instance when available.
     /// With the URLSession http client the request's progress only works on iOS 11.0, macOS 10.13, macCatalyst 13.0, tvOS 11.0, watchOS 4.0.
     /// If you need to get the request's progress in older OS versions, please use Alamofire http client.
     internal var onProgressReady: ((Progress) -> Void)?
 
-    required internal init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:]) {
+    required internal init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool) {
         self.method = method
         self.URLString = URLString
         self.parameters = parameters
         self.headers = headers
+        self.requiresAuthentication = requiresAuthentication
 
         addHeaders(OpenAPIClientAPI.customHeaders)
     }

--- a/Sources/ImmutableXCore/Generated/APIs/AssetsAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/AssetsAPI.swift
@@ -22,7 +22,8 @@ internal class AssetsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getAsset(tokenAddress: String, tokenId: String, includeFees: Bool? = nil) async throws -> Asset {
-        var requestTask: RequestTask?
+        let requestBuilder = getAssetWithRequestBuilder(tokenAddress: tokenAddress, tokenId: tokenId, includeFees: includeFees)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -31,7 +32,7 @@ internal class AssetsAPI {
                   return
                 }
 
-                requestTask = getAssetWithRequestBuilder(tokenAddress: tokenAddress, tokenId: tokenId, includeFees: includeFees).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -40,8 +41,8 @@ internal class AssetsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -67,7 +68,7 @@ internal class AssetsAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "include_fees": includeFees?.encodeToJSON(),
+            "include_fees": (wrappedValue: includeFees?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -78,7 +79,7 @@ internal class AssetsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Asset>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -112,7 +113,8 @@ internal class AssetsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listAssets(pageSize: Int? = nil, cursor: String? = nil, orderBy: OrderBy_listAssets? = nil, direction: String? = nil, user: String? = nil, status: String? = nil, name: String? = nil, metadata: String? = nil, sellOrders: Bool? = nil, buyOrders: Bool? = nil, includeFees: Bool? = nil, collection: String? = nil, updatedMinTimestamp: String? = nil, updatedMaxTimestamp: String? = nil, auxiliaryFeePercentages: String? = nil, auxiliaryFeeRecipients: String? = nil) async throws -> ListAssetsResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listAssetsWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, name: name, metadata: metadata, sellOrders: sellOrders, buyOrders: buyOrders, includeFees: includeFees, collection: collection, updatedMinTimestamp: updatedMinTimestamp, updatedMaxTimestamp: updatedMaxTimestamp, auxiliaryFeePercentages: auxiliaryFeePercentages, auxiliaryFeeRecipients: auxiliaryFeeRecipients)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -121,7 +123,7 @@ internal class AssetsAPI {
                   return
                 }
 
-                requestTask = listAssetsWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, name: name, metadata: metadata, sellOrders: sellOrders, buyOrders: buyOrders, includeFees: includeFees, collection: collection, updatedMinTimestamp: updatedMinTimestamp, updatedMaxTimestamp: updatedMaxTimestamp, auxiliaryFeePercentages: auxiliaryFeePercentages, auxiliaryFeeRecipients: auxiliaryFeeRecipients).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -130,8 +132,8 @@ internal class AssetsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -164,22 +166,22 @@ internal class AssetsAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "page_size": pageSize?.encodeToJSON(),
-            "cursor": cursor?.encodeToJSON(),
-            "order_by": orderBy?.encodeToJSON(),
-            "direction": direction?.encodeToJSON(),
-            "user": user?.encodeToJSON(),
-            "status": status?.encodeToJSON(),
-            "name": name?.encodeToJSON(),
-            "metadata": metadata?.encodeToJSON(),
-            "sell_orders": sellOrders?.encodeToJSON(),
-            "buy_orders": buyOrders?.encodeToJSON(),
-            "include_fees": includeFees?.encodeToJSON(),
-            "collection": collection?.encodeToJSON(),
-            "updated_min_timestamp": updatedMinTimestamp?.encodeToJSON(),
-            "updated_max_timestamp": updatedMaxTimestamp?.encodeToJSON(),
-            "auxiliary_fee_percentages": auxiliaryFeePercentages?.encodeToJSON(),
-            "auxiliary_fee_recipients": auxiliaryFeeRecipients?.encodeToJSON(),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "cursor": (wrappedValue: cursor?.encodeToJSON(), isExplode: false),
+            "order_by": (wrappedValue: orderBy?.encodeToJSON(), isExplode: false),
+            "direction": (wrappedValue: direction?.encodeToJSON(), isExplode: false),
+            "user": (wrappedValue: user?.encodeToJSON(), isExplode: false),
+            "status": (wrappedValue: status?.encodeToJSON(), isExplode: false),
+            "name": (wrappedValue: name?.encodeToJSON(), isExplode: false),
+            "metadata": (wrappedValue: metadata?.encodeToJSON(), isExplode: false),
+            "sell_orders": (wrappedValue: sellOrders?.encodeToJSON(), isExplode: false),
+            "buy_orders": (wrappedValue: buyOrders?.encodeToJSON(), isExplode: false),
+            "include_fees": (wrappedValue: includeFees?.encodeToJSON(), isExplode: false),
+            "collection": (wrappedValue: collection?.encodeToJSON(), isExplode: false),
+            "updated_min_timestamp": (wrappedValue: updatedMinTimestamp?.encodeToJSON(), isExplode: false),
+            "updated_max_timestamp": (wrappedValue: updatedMaxTimestamp?.encodeToJSON(), isExplode: false),
+            "auxiliary_fee_percentages": (wrappedValue: auxiliaryFeePercentages?.encodeToJSON(), isExplode: false),
+            "auxiliary_fee_recipients": (wrappedValue: auxiliaryFeeRecipients?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -190,6 +192,6 @@ internal class AssetsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListAssetsResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/BalancesAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/BalancesAPI.swift
@@ -21,7 +21,8 @@ internal class BalancesAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getBalance(owner: String, address: String) async throws -> Balance {
-        var requestTask: RequestTask?
+        let requestBuilder = getBalanceWithRequestBuilder(owner: owner, address: address)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -30,7 +31,7 @@ internal class BalancesAPI {
                   return
                 }
 
-                requestTask = getBalanceWithRequestBuilder(owner: owner, address: address).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -39,8 +40,8 @@ internal class BalancesAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -73,7 +74,7 @@ internal class BalancesAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Balance>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -84,7 +85,8 @@ internal class BalancesAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listBalances(owner: String) async throws -> ListBalancesResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listBalancesWithRequestBuilder(owner: owner)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -93,7 +95,7 @@ internal class BalancesAPI {
                   return
                 }
 
-                requestTask = listBalancesWithRequestBuilder(owner: owner).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -102,8 +104,8 @@ internal class BalancesAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -132,6 +134,6 @@ internal class BalancesAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListBalancesResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/CollectionsAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/CollectionsAPI.swift
@@ -22,7 +22,8 @@ internal class CollectionsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func createCollection(iMXSignature: String, iMXTimestamp: String, createCollectionRequest: CreateCollectionRequest) async throws -> Collection {
-        var requestTask: RequestTask?
+        let requestBuilder = createCollectionWithRequestBuilder(iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, createCollectionRequest: createCollectionRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -31,7 +32,7 @@ internal class CollectionsAPI {
                   return
                 }
 
-                requestTask = createCollectionWithRequestBuilder(iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, createCollectionRequest: createCollectionRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -40,8 +41,8 @@ internal class CollectionsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -71,7 +72,7 @@ internal class CollectionsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Collection>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -82,7 +83,8 @@ internal class CollectionsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getCollection(address: String) async throws -> Collection {
-        var requestTask: RequestTask?
+        let requestBuilder = getCollectionWithRequestBuilder(address: address)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -91,7 +93,7 @@ internal class CollectionsAPI {
                   return
                 }
 
-                requestTask = getCollectionWithRequestBuilder(address: address).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -100,8 +102,8 @@ internal class CollectionsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -130,7 +132,7 @@ internal class CollectionsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Collection>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -143,7 +145,8 @@ internal class CollectionsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listCollectionFilters(address: String, pageSize: Int? = nil, nextPageToken: String? = nil) async throws -> CollectionFilter {
-        var requestTask: RequestTask?
+        let requestBuilder = listCollectionFiltersWithRequestBuilder(address: address, pageSize: pageSize, nextPageToken: nextPageToken)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -152,7 +155,7 @@ internal class CollectionsAPI {
                   return
                 }
 
-                requestTask = listCollectionFiltersWithRequestBuilder(address: address, pageSize: pageSize, nextPageToken: nextPageToken).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -161,8 +164,8 @@ internal class CollectionsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -185,8 +188,8 @@ internal class CollectionsAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "page_size": pageSize?.encodeToJSON(),
-            "next_page_token": nextPageToken?.encodeToJSON(),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "next_page_token": (wrappedValue: nextPageToken?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -197,7 +200,7 @@ internal class CollectionsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<CollectionFilter>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -225,7 +228,8 @@ internal class CollectionsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listCollections(pageSize: Int? = nil, cursor: String? = nil, orderBy: OrderBy_listCollections? = nil, direction: String? = nil, blacklist: String? = nil, whitelist: String? = nil, keyword: String? = nil) async throws -> ListCollectionsResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listCollectionsWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, blacklist: blacklist, whitelist: whitelist, keyword: keyword)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -234,7 +238,7 @@ internal class CollectionsAPI {
                   return
                 }
 
-                requestTask = listCollectionsWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, blacklist: blacklist, whitelist: whitelist, keyword: keyword).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -243,8 +247,8 @@ internal class CollectionsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -268,13 +272,13 @@ internal class CollectionsAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "page_size": pageSize?.encodeToJSON(),
-            "cursor": cursor?.encodeToJSON(),
-            "order_by": orderBy?.encodeToJSON(),
-            "direction": direction?.encodeToJSON(),
-            "blacklist": blacklist?.encodeToJSON(),
-            "whitelist": whitelist?.encodeToJSON(),
-            "keyword": keyword?.encodeToJSON(),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "cursor": (wrappedValue: cursor?.encodeToJSON(), isExplode: false),
+            "order_by": (wrappedValue: orderBy?.encodeToJSON(), isExplode: false),
+            "direction": (wrappedValue: direction?.encodeToJSON(), isExplode: false),
+            "blacklist": (wrappedValue: blacklist?.encodeToJSON(), isExplode: false),
+            "whitelist": (wrappedValue: whitelist?.encodeToJSON(), isExplode: false),
+            "keyword": (wrappedValue: keyword?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -285,7 +289,7 @@ internal class CollectionsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListCollectionsResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -299,7 +303,8 @@ internal class CollectionsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func updateCollection(address: String, iMXSignature: String, iMXTimestamp: String, updateCollectionRequest: UpdateCollectionRequest) async throws -> Collection {
-        var requestTask: RequestTask?
+        let requestBuilder = updateCollectionWithRequestBuilder(address: address, iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, updateCollectionRequest: updateCollectionRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -308,7 +313,7 @@ internal class CollectionsAPI {
                   return
                 }
 
-                requestTask = updateCollectionWithRequestBuilder(address: address, iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, updateCollectionRequest: updateCollectionRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -317,8 +322,8 @@ internal class CollectionsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -351,6 +356,6 @@ internal class CollectionsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Collection>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "PATCH", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "PATCH", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/DepositsAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/DepositsAPI.swift
@@ -20,7 +20,8 @@ internal class DepositsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getDeposit(id: String) async throws -> Deposit {
-        var requestTask: RequestTask?
+        let requestBuilder = getDepositWithRequestBuilder(id: id)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +30,7 @@ internal class DepositsAPI {
                   return
                 }
 
-                requestTask = getDepositWithRequestBuilder(id: id).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -38,8 +39,8 @@ internal class DepositsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -68,7 +69,7 @@ internal class DepositsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Deposit>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -79,7 +80,8 @@ internal class DepositsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getSignableDeposit(getSignableDepositRequest: GetSignableDepositRequest) async throws -> GetSignableDepositResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getSignableDepositWithRequestBuilder(getSignableDepositRequest: getSignableDepositRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -88,7 +90,7 @@ internal class DepositsAPI {
                   return
                 }
 
-                requestTask = getSignableDepositWithRequestBuilder(getSignableDepositRequest: getSignableDepositRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -97,8 +99,8 @@ internal class DepositsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -124,7 +126,7 @@ internal class DepositsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetSignableDepositResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -150,7 +152,8 @@ internal class DepositsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listDeposits(pageSize: Int? = nil, cursor: String? = nil, orderBy: String? = nil, direction: String? = nil, user: String? = nil, status: String? = nil, updatedMinTimestamp: String? = nil, updatedMaxTimestamp: String? = nil, tokenType: String? = nil, tokenId: String? = nil, assetId: String? = nil, tokenAddress: String? = nil, tokenName: String? = nil, minQuantity: String? = nil, maxQuantity: String? = nil, metadata: String? = nil) async throws -> ListDepositsResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listDepositsWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, updatedMinTimestamp: updatedMinTimestamp, updatedMaxTimestamp: updatedMaxTimestamp, tokenType: tokenType, tokenId: tokenId, assetId: assetId, tokenAddress: tokenAddress, tokenName: tokenName, minQuantity: minQuantity, maxQuantity: maxQuantity, metadata: metadata)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -159,7 +162,7 @@ internal class DepositsAPI {
                   return
                 }
 
-                requestTask = listDepositsWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, updatedMinTimestamp: updatedMinTimestamp, updatedMaxTimestamp: updatedMaxTimestamp, tokenType: tokenType, tokenId: tokenId, assetId: assetId, tokenAddress: tokenAddress, tokenName: tokenName, minQuantity: minQuantity, maxQuantity: maxQuantity, metadata: metadata).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -168,8 +171,8 @@ internal class DepositsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -202,22 +205,22 @@ internal class DepositsAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "page_size": pageSize?.encodeToJSON(),
-            "cursor": cursor?.encodeToJSON(),
-            "order_by": orderBy?.encodeToJSON(),
-            "direction": direction?.encodeToJSON(),
-            "user": user?.encodeToJSON(),
-            "status": status?.encodeToJSON(),
-            "updated_min_timestamp": updatedMinTimestamp?.encodeToJSON(),
-            "updated_max_timestamp": updatedMaxTimestamp?.encodeToJSON(),
-            "token_type": tokenType?.encodeToJSON(),
-            "token_id": tokenId?.encodeToJSON(),
-            "asset_id": assetId?.encodeToJSON(),
-            "token_address": tokenAddress?.encodeToJSON(),
-            "token_name": tokenName?.encodeToJSON(),
-            "min_quantity": minQuantity?.encodeToJSON(),
-            "max_quantity": maxQuantity?.encodeToJSON(),
-            "metadata": metadata?.encodeToJSON(),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "cursor": (wrappedValue: cursor?.encodeToJSON(), isExplode: false),
+            "order_by": (wrappedValue: orderBy?.encodeToJSON(), isExplode: false),
+            "direction": (wrappedValue: direction?.encodeToJSON(), isExplode: false),
+            "user": (wrappedValue: user?.encodeToJSON(), isExplode: false),
+            "status": (wrappedValue: status?.encodeToJSON(), isExplode: false),
+            "updated_min_timestamp": (wrappedValue: updatedMinTimestamp?.encodeToJSON(), isExplode: false),
+            "updated_max_timestamp": (wrappedValue: updatedMaxTimestamp?.encodeToJSON(), isExplode: false),
+            "token_type": (wrappedValue: tokenType?.encodeToJSON(), isExplode: false),
+            "token_id": (wrappedValue: tokenId?.encodeToJSON(), isExplode: false),
+            "asset_id": (wrappedValue: assetId?.encodeToJSON(), isExplode: false),
+            "token_address": (wrappedValue: tokenAddress?.encodeToJSON(), isExplode: false),
+            "token_name": (wrappedValue: tokenName?.encodeToJSON(), isExplode: false),
+            "min_quantity": (wrappedValue: minQuantity?.encodeToJSON(), isExplode: false),
+            "max_quantity": (wrappedValue: maxQuantity?.encodeToJSON(), isExplode: false),
+            "metadata": (wrappedValue: metadata?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -228,6 +231,6 @@ internal class DepositsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListDepositsResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/EncodingAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/EncodingAPI.swift
@@ -21,7 +21,8 @@ internal class EncodingAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func encodeAsset(assetType: String, encodeAssetRequest: EncodeAssetRequest) async throws -> EncodeAssetResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = encodeAssetWithRequestBuilder(assetType: assetType, encodeAssetRequest: encodeAssetRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -30,7 +31,7 @@ internal class EncodingAPI {
                   return
                 }
 
-                requestTask = encodeAssetWithRequestBuilder(assetType: assetType, encodeAssetRequest: encodeAssetRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -39,8 +40,8 @@ internal class EncodingAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -70,6 +71,6 @@ internal class EncodingAPI {
 
         let localVariableRequestBuilder: RequestBuilder<EncodeAssetResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/MetadataAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/MetadataAPI.swift
@@ -23,7 +23,8 @@ internal class MetadataAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func addMetadataSchemaToCollection(address: String, iMXSignature: String, iMXTimestamp: String, addMetadataSchemaToCollectionRequest: AddMetadataSchemaToCollectionRequest) async throws -> SuccessResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = addMetadataSchemaToCollectionWithRequestBuilder(address: address, iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, addMetadataSchemaToCollectionRequest: addMetadataSchemaToCollectionRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -32,7 +33,7 @@ internal class MetadataAPI {
                   return
                 }
 
-                requestTask = addMetadataSchemaToCollectionWithRequestBuilder(address: address, iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, addMetadataSchemaToCollectionRequest: addMetadataSchemaToCollectionRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -41,8 +42,8 @@ internal class MetadataAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -75,7 +76,7 @@ internal class MetadataAPI {
 
         let localVariableRequestBuilder: RequestBuilder<SuccessResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -86,7 +87,8 @@ internal class MetadataAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getMetadataSchema(address: String) async throws -> [MetadataSchemaProperty] {
-        var requestTask: RequestTask?
+        let requestBuilder = getMetadataSchemaWithRequestBuilder(address: address)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -95,7 +97,7 @@ internal class MetadataAPI {
                   return
                 }
 
-                requestTask = getMetadataSchemaWithRequestBuilder(address: address).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -104,8 +106,8 @@ internal class MetadataAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -134,7 +136,7 @@ internal class MetadataAPI {
 
         let localVariableRequestBuilder: RequestBuilder<[MetadataSchemaProperty]>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -149,7 +151,8 @@ internal class MetadataAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func updateMetadataSchemaByName(address: String, name: String, iMXSignature: String, iMXTimestamp: String, metadataSchemaRequest: MetadataSchemaRequest) async throws -> SuccessResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = updateMetadataSchemaByNameWithRequestBuilder(address: address, name: name, iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, metadataSchemaRequest: metadataSchemaRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -158,7 +161,7 @@ internal class MetadataAPI {
                   return
                 }
 
-                requestTask = updateMetadataSchemaByNameWithRequestBuilder(address: address, name: name, iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, metadataSchemaRequest: metadataSchemaRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -167,8 +170,8 @@ internal class MetadataAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -205,6 +208,6 @@ internal class MetadataAPI {
 
         let localVariableRequestBuilder: RequestBuilder<SuccessResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "PATCH", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "PATCH", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/MintsAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/MintsAPI.swift
@@ -20,7 +20,8 @@ internal class MintsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getMint(id: String) async throws -> Mint {
-        var requestTask: RequestTask?
+        let requestBuilder = getMintWithRequestBuilder(id: id)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +30,7 @@ internal class MintsAPI {
                   return
                 }
 
-                requestTask = getMintWithRequestBuilder(id: id).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -38,8 +39,8 @@ internal class MintsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -68,7 +69,7 @@ internal class MintsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Mint>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -80,7 +81,8 @@ internal class MintsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getMintableTokenDetailsByClientTokenId(tokenAddress: String, tokenId: String) async throws -> MintableTokenDetails {
-        var requestTask: RequestTask?
+        let requestBuilder = getMintableTokenDetailsByClientTokenIdWithRequestBuilder(tokenAddress: tokenAddress, tokenId: tokenId)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -89,7 +91,7 @@ internal class MintsAPI {
                   return
                 }
 
-                requestTask = getMintableTokenDetailsByClientTokenIdWithRequestBuilder(tokenAddress: tokenAddress, tokenId: tokenId).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -98,8 +100,8 @@ internal class MintsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -132,7 +134,7 @@ internal class MintsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<MintableTokenDetails>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -158,7 +160,8 @@ internal class MintsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listMints(pageSize: Int? = nil, cursor: String? = nil, orderBy: String? = nil, direction: String? = nil, user: String? = nil, status: String? = nil, minTimestamp: String? = nil, maxTimestamp: String? = nil, tokenType: String? = nil, tokenId: String? = nil, assetId: String? = nil, tokenName: String? = nil, tokenAddress: String? = nil, minQuantity: String? = nil, maxQuantity: String? = nil, metadata: String? = nil) async throws -> ListMintsResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listMintsWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp, tokenType: tokenType, tokenId: tokenId, assetId: assetId, tokenName: tokenName, tokenAddress: tokenAddress, minQuantity: minQuantity, maxQuantity: maxQuantity, metadata: metadata)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -167,7 +170,7 @@ internal class MintsAPI {
                   return
                 }
 
-                requestTask = listMintsWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp, tokenType: tokenType, tokenId: tokenId, assetId: assetId, tokenName: tokenName, tokenAddress: tokenAddress, minQuantity: minQuantity, maxQuantity: maxQuantity, metadata: metadata).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -176,8 +179,8 @@ internal class MintsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -210,22 +213,22 @@ internal class MintsAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "page_size": pageSize?.encodeToJSON(),
-            "cursor": cursor?.encodeToJSON(),
-            "order_by": orderBy?.encodeToJSON(),
-            "direction": direction?.encodeToJSON(),
-            "user": user?.encodeToJSON(),
-            "status": status?.encodeToJSON(),
-            "min_timestamp": minTimestamp?.encodeToJSON(),
-            "max_timestamp": maxTimestamp?.encodeToJSON(),
-            "token_type": tokenType?.encodeToJSON(),
-            "token_id": tokenId?.encodeToJSON(),
-            "asset_id": assetId?.encodeToJSON(),
-            "token_name": tokenName?.encodeToJSON(),
-            "token_address": tokenAddress?.encodeToJSON(),
-            "min_quantity": minQuantity?.encodeToJSON(),
-            "max_quantity": maxQuantity?.encodeToJSON(),
-            "metadata": metadata?.encodeToJSON(),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "cursor": (wrappedValue: cursor?.encodeToJSON(), isExplode: false),
+            "order_by": (wrappedValue: orderBy?.encodeToJSON(), isExplode: false),
+            "direction": (wrappedValue: direction?.encodeToJSON(), isExplode: false),
+            "user": (wrappedValue: user?.encodeToJSON(), isExplode: false),
+            "status": (wrappedValue: status?.encodeToJSON(), isExplode: false),
+            "min_timestamp": (wrappedValue: minTimestamp?.encodeToJSON(), isExplode: false),
+            "max_timestamp": (wrappedValue: maxTimestamp?.encodeToJSON(), isExplode: false),
+            "token_type": (wrappedValue: tokenType?.encodeToJSON(), isExplode: false),
+            "token_id": (wrappedValue: tokenId?.encodeToJSON(), isExplode: false),
+            "asset_id": (wrappedValue: assetId?.encodeToJSON(), isExplode: false),
+            "token_name": (wrappedValue: tokenName?.encodeToJSON(), isExplode: false),
+            "token_address": (wrappedValue: tokenAddress?.encodeToJSON(), isExplode: false),
+            "min_quantity": (wrappedValue: minQuantity?.encodeToJSON(), isExplode: false),
+            "max_quantity": (wrappedValue: maxQuantity?.encodeToJSON(), isExplode: false),
+            "metadata": (wrappedValue: metadata?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -236,7 +239,7 @@ internal class MintsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListMintsResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -247,7 +250,8 @@ internal class MintsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func mintTokens(mintTokensRequestV2: [MintRequest]) async throws -> MintTokensResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = mintTokensWithRequestBuilder(mintTokensRequestV2: mintTokensRequestV2)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -256,7 +260,7 @@ internal class MintsAPI {
                   return
                 }
 
-                requestTask = mintTokensWithRequestBuilder(mintTokensRequestV2: mintTokensRequestV2).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -265,8 +269,8 @@ internal class MintsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -293,6 +297,6 @@ internal class MintsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<MintTokensResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/OrdersAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/OrdersAPI.swift
@@ -23,7 +23,8 @@ internal class OrdersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func cancelOrder(xImxEthAddress: String, xImxEthSignature: String, id: String, cancelOrderRequest: CancelOrderRequest) async throws -> CancelOrderResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = cancelOrderWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, id: id, cancelOrderRequest: cancelOrderRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -32,7 +33,7 @@ internal class OrdersAPI {
                   return
                 }
 
-                requestTask = cancelOrderWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, id: id, cancelOrderRequest: cancelOrderRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -41,8 +42,8 @@ internal class OrdersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -75,7 +76,7 @@ internal class OrdersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<CancelOrderResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "DELETE", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "DELETE", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -88,7 +89,8 @@ internal class OrdersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func createOrder(xImxEthAddress: String, xImxEthSignature: String, createOrderRequest: CreateOrderRequest) async throws -> CreateOrderResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = createOrderWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createOrderRequest: createOrderRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -97,7 +99,7 @@ internal class OrdersAPI {
                   return
                 }
 
-                requestTask = createOrderWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createOrderRequest: createOrderRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -106,8 +108,8 @@ internal class OrdersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -136,7 +138,7 @@ internal class OrdersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<CreateOrderResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -150,7 +152,8 @@ internal class OrdersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getOrder(id: String, includeFees: Bool? = nil, auxiliaryFeePercentages: String? = nil, auxiliaryFeeRecipients: String? = nil) async throws -> Order {
-        var requestTask: RequestTask?
+        let requestBuilder = getOrderWithRequestBuilder(id: id, includeFees: includeFees, auxiliaryFeePercentages: auxiliaryFeePercentages, auxiliaryFeeRecipients: auxiliaryFeeRecipients)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -159,7 +162,7 @@ internal class OrdersAPI {
                   return
                 }
 
-                requestTask = getOrderWithRequestBuilder(id: id, includeFees: includeFees, auxiliaryFeePercentages: auxiliaryFeePercentages, auxiliaryFeeRecipients: auxiliaryFeeRecipients).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -168,8 +171,8 @@ internal class OrdersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -193,9 +196,9 @@ internal class OrdersAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "include_fees": includeFees?.encodeToJSON(),
-            "auxiliary_fee_percentages": auxiliaryFeePercentages?.encodeToJSON(),
-            "auxiliary_fee_recipients": auxiliaryFeeRecipients?.encodeToJSON(),
+            "include_fees": (wrappedValue: includeFees?.encodeToJSON(), isExplode: false),
+            "auxiliary_fee_percentages": (wrappedValue: auxiliaryFeePercentages?.encodeToJSON(), isExplode: false),
+            "auxiliary_fee_recipients": (wrappedValue: auxiliaryFeeRecipients?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -206,7 +209,7 @@ internal class OrdersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Order>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -217,7 +220,8 @@ internal class OrdersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getSignableCancelOrder(getSignableCancelOrderRequest: GetSignableCancelOrderRequest) async throws -> GetSignableCancelOrderResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getSignableCancelOrderWithRequestBuilder(getSignableCancelOrderRequest: getSignableCancelOrderRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -226,7 +230,7 @@ internal class OrdersAPI {
                   return
                 }
 
-                requestTask = getSignableCancelOrderWithRequestBuilder(getSignableCancelOrderRequest: getSignableCancelOrderRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -235,8 +239,8 @@ internal class OrdersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -262,7 +266,7 @@ internal class OrdersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetSignableCancelOrderResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -273,7 +277,8 @@ internal class OrdersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getSignableOrder(getSignableOrderRequestV3: GetSignableOrderRequest) async throws -> GetSignableOrderResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getSignableOrderWithRequestBuilder(getSignableOrderRequestV3: getSignableOrderRequestV3)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -282,7 +287,7 @@ internal class OrdersAPI {
                   return
                 }
 
-                requestTask = getSignableOrderWithRequestBuilder(getSignableOrderRequestV3: getSignableOrderRequestV3).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -291,8 +296,8 @@ internal class OrdersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -318,7 +323,7 @@ internal class OrdersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetSignableOrderResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -380,7 +385,8 @@ internal class OrdersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listOrders(pageSize: Int? = nil, cursor: String? = nil, orderBy: OrderBy_listOrders? = nil, direction: String? = nil, user: String? = nil, status: Status_listOrders? = nil, minTimestamp: String? = nil, maxTimestamp: String? = nil, updatedMinTimestamp: String? = nil, updatedMaxTimestamp: String? = nil, buyTokenType: String? = nil, buyTokenId: String? = nil, buyAssetId: String? = nil, buyTokenAddress: String? = nil, buyTokenName: String? = nil, buyMinQuantity: String? = nil, buyMaxQuantity: String? = nil, buyMetadata: String? = nil, sellTokenType: String? = nil, sellTokenId: String? = nil, sellAssetId: String? = nil, sellTokenAddress: String? = nil, sellTokenName: String? = nil, sellMinQuantity: String? = nil, sellMaxQuantity: String? = nil, sellMetadata: String? = nil, auxiliaryFeePercentages: String? = nil, auxiliaryFeeRecipients: String? = nil, includeFees: Bool? = nil) async throws -> ListOrdersResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listOrdersWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp, updatedMinTimestamp: updatedMinTimestamp, updatedMaxTimestamp: updatedMaxTimestamp, buyTokenType: buyTokenType, buyTokenId: buyTokenId, buyAssetId: buyAssetId, buyTokenAddress: buyTokenAddress, buyTokenName: buyTokenName, buyMinQuantity: buyMinQuantity, buyMaxQuantity: buyMaxQuantity, buyMetadata: buyMetadata, sellTokenType: sellTokenType, sellTokenId: sellTokenId, sellAssetId: sellAssetId, sellTokenAddress: sellTokenAddress, sellTokenName: sellTokenName, sellMinQuantity: sellMinQuantity, sellMaxQuantity: sellMaxQuantity, sellMetadata: sellMetadata, auxiliaryFeePercentages: auxiliaryFeePercentages, auxiliaryFeeRecipients: auxiliaryFeeRecipients, includeFees: includeFees)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -389,7 +395,7 @@ internal class OrdersAPI {
                   return
                 }
 
-                requestTask = listOrdersWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp, updatedMinTimestamp: updatedMinTimestamp, updatedMaxTimestamp: updatedMaxTimestamp, buyTokenType: buyTokenType, buyTokenId: buyTokenId, buyAssetId: buyAssetId, buyTokenAddress: buyTokenAddress, buyTokenName: buyTokenName, buyMinQuantity: buyMinQuantity, buyMaxQuantity: buyMaxQuantity, buyMetadata: buyMetadata, sellTokenType: sellTokenType, sellTokenId: sellTokenId, sellAssetId: sellAssetId, sellTokenAddress: sellTokenAddress, sellTokenName: sellTokenName, sellMinQuantity: sellMinQuantity, sellMaxQuantity: sellMaxQuantity, sellMetadata: sellMetadata, auxiliaryFeePercentages: auxiliaryFeePercentages, auxiliaryFeeRecipients: auxiliaryFeeRecipients, includeFees: includeFees).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -398,8 +404,8 @@ internal class OrdersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -445,35 +451,35 @@ internal class OrdersAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "page_size": pageSize?.encodeToJSON(),
-            "cursor": cursor?.encodeToJSON(),
-            "order_by": orderBy?.encodeToJSON(),
-            "direction": direction?.encodeToJSON(),
-            "user": user?.encodeToJSON(),
-            "status": status?.encodeToJSON(),
-            "min_timestamp": minTimestamp?.encodeToJSON(),
-            "max_timestamp": maxTimestamp?.encodeToJSON(),
-            "updated_min_timestamp": updatedMinTimestamp?.encodeToJSON(),
-            "updated_max_timestamp": updatedMaxTimestamp?.encodeToJSON(),
-            "buy_token_type": buyTokenType?.encodeToJSON(),
-            "buy_token_id": buyTokenId?.encodeToJSON(),
-            "buy_asset_id": buyAssetId?.encodeToJSON(),
-            "buy_token_address": buyTokenAddress?.encodeToJSON(),
-            "buy_token_name": buyTokenName?.encodeToJSON(),
-            "buy_min_quantity": buyMinQuantity?.encodeToJSON(),
-            "buy_max_quantity": buyMaxQuantity?.encodeToJSON(),
-            "buy_metadata": buyMetadata?.encodeToJSON(),
-            "sell_token_type": sellTokenType?.encodeToJSON(),
-            "sell_token_id": sellTokenId?.encodeToJSON(),
-            "sell_asset_id": sellAssetId?.encodeToJSON(),
-            "sell_token_address": sellTokenAddress?.encodeToJSON(),
-            "sell_token_name": sellTokenName?.encodeToJSON(),
-            "sell_min_quantity": sellMinQuantity?.encodeToJSON(),
-            "sell_max_quantity": sellMaxQuantity?.encodeToJSON(),
-            "sell_metadata": sellMetadata?.encodeToJSON(),
-            "auxiliary_fee_percentages": auxiliaryFeePercentages?.encodeToJSON(),
-            "auxiliary_fee_recipients": auxiliaryFeeRecipients?.encodeToJSON(),
-            "include_fees": includeFees?.encodeToJSON(),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "cursor": (wrappedValue: cursor?.encodeToJSON(), isExplode: false),
+            "order_by": (wrappedValue: orderBy?.encodeToJSON(), isExplode: false),
+            "direction": (wrappedValue: direction?.encodeToJSON(), isExplode: false),
+            "user": (wrappedValue: user?.encodeToJSON(), isExplode: false),
+            "status": (wrappedValue: status?.encodeToJSON(), isExplode: false),
+            "min_timestamp": (wrappedValue: minTimestamp?.encodeToJSON(), isExplode: false),
+            "max_timestamp": (wrappedValue: maxTimestamp?.encodeToJSON(), isExplode: false),
+            "updated_min_timestamp": (wrappedValue: updatedMinTimestamp?.encodeToJSON(), isExplode: false),
+            "updated_max_timestamp": (wrappedValue: updatedMaxTimestamp?.encodeToJSON(), isExplode: false),
+            "buy_token_type": (wrappedValue: buyTokenType?.encodeToJSON(), isExplode: false),
+            "buy_token_id": (wrappedValue: buyTokenId?.encodeToJSON(), isExplode: false),
+            "buy_asset_id": (wrappedValue: buyAssetId?.encodeToJSON(), isExplode: false),
+            "buy_token_address": (wrappedValue: buyTokenAddress?.encodeToJSON(), isExplode: false),
+            "buy_token_name": (wrappedValue: buyTokenName?.encodeToJSON(), isExplode: false),
+            "buy_min_quantity": (wrappedValue: buyMinQuantity?.encodeToJSON(), isExplode: false),
+            "buy_max_quantity": (wrappedValue: buyMaxQuantity?.encodeToJSON(), isExplode: false),
+            "buy_metadata": (wrappedValue: buyMetadata?.encodeToJSON(), isExplode: false),
+            "sell_token_type": (wrappedValue: sellTokenType?.encodeToJSON(), isExplode: false),
+            "sell_token_id": (wrappedValue: sellTokenId?.encodeToJSON(), isExplode: false),
+            "sell_asset_id": (wrappedValue: sellAssetId?.encodeToJSON(), isExplode: false),
+            "sell_token_address": (wrappedValue: sellTokenAddress?.encodeToJSON(), isExplode: false),
+            "sell_token_name": (wrappedValue: sellTokenName?.encodeToJSON(), isExplode: false),
+            "sell_min_quantity": (wrappedValue: sellMinQuantity?.encodeToJSON(), isExplode: false),
+            "sell_max_quantity": (wrappedValue: sellMaxQuantity?.encodeToJSON(), isExplode: false),
+            "sell_metadata": (wrappedValue: sellMetadata?.encodeToJSON(), isExplode: false),
+            "auxiliary_fee_percentages": (wrappedValue: auxiliaryFeePercentages?.encodeToJSON(), isExplode: false),
+            "auxiliary_fee_recipients": (wrappedValue: auxiliaryFeeRecipients?.encodeToJSON(), isExplode: false),
+            "include_fees": (wrappedValue: includeFees?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -484,6 +490,6 @@ internal class OrdersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListOrdersResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/ProjectsAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/ProjectsAPI.swift
@@ -22,7 +22,8 @@ internal class ProjectsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func createProject(iMXSignature: String, iMXTimestamp: String, createProjectRequest: CreateProjectRequest) async throws -> CreateProjectResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = createProjectWithRequestBuilder(iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, createProjectRequest: createProjectRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -31,7 +32,7 @@ internal class ProjectsAPI {
                   return
                 }
 
-                requestTask = createProjectWithRequestBuilder(iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, createProjectRequest: createProjectRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -40,8 +41,8 @@ internal class ProjectsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -70,7 +71,7 @@ internal class ProjectsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<CreateProjectResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -83,7 +84,8 @@ internal class ProjectsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getProject(id: String, iMXSignature: String, iMXTimestamp: String) async throws -> Project {
-        var requestTask: RequestTask?
+        let requestBuilder = getProjectWithRequestBuilder(id: id, iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -92,7 +94,7 @@ internal class ProjectsAPI {
                   return
                 }
 
-                requestTask = getProjectWithRequestBuilder(id: id, iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -101,8 +103,8 @@ internal class ProjectsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -134,7 +136,7 @@ internal class ProjectsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Project>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -150,7 +152,8 @@ internal class ProjectsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getProjects(iMXSignature: String, iMXTimestamp: String, pageSize: Int? = nil, cursor: String? = nil, orderBy: String? = nil, direction: String? = nil) async throws -> GetProjectsResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getProjectsWithRequestBuilder(iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -159,7 +162,7 @@ internal class ProjectsAPI {
                   return
                 }
 
-                requestTask = getProjectsWithRequestBuilder(iMXSignature: iMXSignature, iMXTimestamp: iMXTimestamp, pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -168,8 +171,8 @@ internal class ProjectsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -192,10 +195,10 @@ internal class ProjectsAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "page_size": pageSize?.encodeToJSON(),
-            "cursor": cursor?.encodeToJSON(),
-            "order_by": orderBy?.encodeToJSON(),
-            "direction": direction?.encodeToJSON(),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "cursor": (wrappedValue: cursor?.encodeToJSON(), isExplode: false),
+            "order_by": (wrappedValue: orderBy?.encodeToJSON(), isExplode: false),
+            "direction": (wrappedValue: direction?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -207,6 +210,6 @@ internal class ProjectsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetProjectsResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/TokensAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/TokensAPI.swift
@@ -20,7 +20,8 @@ internal class TokensAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getToken(address: String) async throws -> TokenDetails {
-        var requestTask: RequestTask?
+        let requestBuilder = getTokenWithRequestBuilder(address: address)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +30,7 @@ internal class TokensAPI {
                   return
                 }
 
-                requestTask = getTokenWithRequestBuilder(address: address).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -38,8 +39,8 @@ internal class TokensAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -68,7 +69,7 @@ internal class TokensAPI {
 
         let localVariableRequestBuilder: RequestBuilder<TokenDetails>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -80,7 +81,8 @@ internal class TokensAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listTokens(address: String? = nil, symbols: String? = nil) async throws -> ListTokensResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listTokensWithRequestBuilder(address: address, symbols: symbols)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -89,7 +91,7 @@ internal class TokensAPI {
                   return
                 }
 
-                requestTask = listTokensWithRequestBuilder(address: address, symbols: symbols).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -98,8 +100,8 @@ internal class TokensAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -118,8 +120,8 @@ internal class TokensAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "address": address?.encodeToJSON(),
-            "symbols": symbols?.encodeToJSON(),
+            "address": (wrappedValue: address?.encodeToJSON(), isExplode: false),
+            "symbols": (wrappedValue: symbols?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -130,6 +132,6 @@ internal class TokensAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListTokensResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/TradesAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/TradesAPI.swift
@@ -22,7 +22,8 @@ internal class TradesAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func createTrade(xImxEthAddress: String, xImxEthSignature: String, createTradeRequest: CreateTradeRequestV1) async throws -> CreateTradeResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = createTradeWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createTradeRequest: createTradeRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -31,7 +32,7 @@ internal class TradesAPI {
                   return
                 }
 
-                requestTask = createTradeWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createTradeRequest: createTradeRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -40,8 +41,8 @@ internal class TradesAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -70,7 +71,7 @@ internal class TradesAPI {
 
         let localVariableRequestBuilder: RequestBuilder<CreateTradeResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -81,7 +82,8 @@ internal class TradesAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getSignableTrade(getSignableTradeRequest: GetSignableTradeRequest) async throws -> GetSignableTradeResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getSignableTradeWithRequestBuilder(getSignableTradeRequest: getSignableTradeRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -90,7 +92,7 @@ internal class TradesAPI {
                   return
                 }
 
-                requestTask = getSignableTradeWithRequestBuilder(getSignableTradeRequest: getSignableTradeRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -99,8 +101,8 @@ internal class TradesAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -126,7 +128,7 @@ internal class TradesAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetSignableTradeResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -137,7 +139,8 @@ internal class TradesAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getTrade(id: String) async throws -> Trade {
-        var requestTask: RequestTask?
+        let requestBuilder = getTradeWithRequestBuilder(id: id)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -146,7 +149,7 @@ internal class TradesAPI {
                   return
                 }
 
-                requestTask = getTradeWithRequestBuilder(id: id).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -155,8 +158,8 @@ internal class TradesAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -185,7 +188,7 @@ internal class TradesAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Trade>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -208,7 +211,8 @@ internal class TradesAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listTrades(partyAOrderId: String? = nil, partyATokenType: String? = nil, partyATokenAddress: String? = nil, partyBOrderId: String? = nil, partyBTokenType: String? = nil, partyBTokenAddress: String? = nil, partyBTokenId: String? = nil, pageSize: Int? = nil, cursor: String? = nil, orderBy: String? = nil, direction: String? = nil, minTimestamp: String? = nil, maxTimestamp: String? = nil) async throws -> ListTradesResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listTradesWithRequestBuilder(partyAOrderId: partyAOrderId, partyATokenType: partyATokenType, partyATokenAddress: partyATokenAddress, partyBOrderId: partyBOrderId, partyBTokenType: partyBTokenType, partyBTokenAddress: partyBTokenAddress, partyBTokenId: partyBTokenId, pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -217,7 +221,7 @@ internal class TradesAPI {
                   return
                 }
 
-                requestTask = listTradesWithRequestBuilder(partyAOrderId: partyAOrderId, partyATokenType: partyATokenType, partyATokenAddress: partyATokenAddress, partyBOrderId: partyBOrderId, partyBTokenType: partyBTokenType, partyBTokenAddress: partyBTokenAddress, partyBTokenId: partyBTokenId, pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -226,8 +230,8 @@ internal class TradesAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -257,19 +261,19 @@ internal class TradesAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "party_a_order_id": partyAOrderId?.encodeToJSON(),
-            "party_a_token_type": partyATokenType?.encodeToJSON(),
-            "party_a_token_address": partyATokenAddress?.encodeToJSON(),
-            "party_b_order_id": partyBOrderId?.encodeToJSON(),
-            "party_b_token_type": partyBTokenType?.encodeToJSON(),
-            "party_b_token_address": partyBTokenAddress?.encodeToJSON(),
-            "party_b_token_id": partyBTokenId?.encodeToJSON(),
-            "page_size": pageSize?.encodeToJSON(),
-            "cursor": cursor?.encodeToJSON(),
-            "order_by": orderBy?.encodeToJSON(),
-            "direction": direction?.encodeToJSON(),
-            "min_timestamp": minTimestamp?.encodeToJSON(),
-            "max_timestamp": maxTimestamp?.encodeToJSON(),
+            "party_a_order_id": (wrappedValue: partyAOrderId?.encodeToJSON(), isExplode: false),
+            "party_a_token_type": (wrappedValue: partyATokenType?.encodeToJSON(), isExplode: false),
+            "party_a_token_address": (wrappedValue: partyATokenAddress?.encodeToJSON(), isExplode: false),
+            "party_b_order_id": (wrappedValue: partyBOrderId?.encodeToJSON(), isExplode: false),
+            "party_b_token_type": (wrappedValue: partyBTokenType?.encodeToJSON(), isExplode: false),
+            "party_b_token_address": (wrappedValue: partyBTokenAddress?.encodeToJSON(), isExplode: false),
+            "party_b_token_id": (wrappedValue: partyBTokenId?.encodeToJSON(), isExplode: false),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "cursor": (wrappedValue: cursor?.encodeToJSON(), isExplode: false),
+            "order_by": (wrappedValue: orderBy?.encodeToJSON(), isExplode: false),
+            "direction": (wrappedValue: direction?.encodeToJSON(), isExplode: false),
+            "min_timestamp": (wrappedValue: minTimestamp?.encodeToJSON(), isExplode: false),
+            "max_timestamp": (wrappedValue: maxTimestamp?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -280,6 +284,6 @@ internal class TradesAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListTradesResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/TransfersAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/TransfersAPI.swift
@@ -22,7 +22,8 @@ internal class TransfersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func createTransfer(xImxEthAddress: String, xImxEthSignature: String, createTransferRequestV2: CreateTransferRequest) async throws -> CreateTransferResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = createTransferWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createTransferRequestV2: createTransferRequestV2)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -31,7 +32,7 @@ internal class TransfersAPI {
                   return
                 }
 
-                requestTask = createTransferWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createTransferRequestV2: createTransferRequestV2).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -40,8 +41,8 @@ internal class TransfersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -70,7 +71,7 @@ internal class TransfersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<CreateTransferResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -83,7 +84,8 @@ internal class TransfersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func createTransferV1(xImxEthAddress: String, xImxEthSignature: String, createTransferRequest: CreateTransferRequestV1) async throws -> CreateTransferResponseV1 {
-        var requestTask: RequestTask?
+        let requestBuilder = createTransferV1WithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createTransferRequest: createTransferRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -92,7 +94,7 @@ internal class TransfersAPI {
                   return
                 }
 
-                requestTask = createTransferV1WithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createTransferRequest: createTransferRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -101,8 +103,8 @@ internal class TransfersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -131,7 +133,7 @@ internal class TransfersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<CreateTransferResponseV1>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -142,7 +144,8 @@ internal class TransfersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getSignableTransfer(getSignableTransferRequestV2: GetSignableTransferRequest) async throws -> GetSignableTransferResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getSignableTransferWithRequestBuilder(getSignableTransferRequestV2: getSignableTransferRequestV2)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -151,7 +154,7 @@ internal class TransfersAPI {
                   return
                 }
 
-                requestTask = getSignableTransferWithRequestBuilder(getSignableTransferRequestV2: getSignableTransferRequestV2).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -160,8 +163,8 @@ internal class TransfersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -187,7 +190,7 @@ internal class TransfersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetSignableTransferResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -198,7 +201,8 @@ internal class TransfersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getSignableTransferV1(getSignableTransferRequest: GetSignableTransferRequestV1) async throws -> GetSignableTransferResponseV1 {
-        var requestTask: RequestTask?
+        let requestBuilder = getSignableTransferV1WithRequestBuilder(getSignableTransferRequest: getSignableTransferRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -207,7 +211,7 @@ internal class TransfersAPI {
                   return
                 }
 
-                requestTask = getSignableTransferV1WithRequestBuilder(getSignableTransferRequest: getSignableTransferRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -216,8 +220,8 @@ internal class TransfersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -243,7 +247,7 @@ internal class TransfersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetSignableTransferResponseV1>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -254,7 +258,8 @@ internal class TransfersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getTransfer(id: String) async throws -> Transfer {
-        var requestTask: RequestTask?
+        let requestBuilder = getTransferWithRequestBuilder(id: id)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -263,7 +268,7 @@ internal class TransfersAPI {
                   return
                 }
 
-                requestTask = getTransferWithRequestBuilder(id: id).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -272,8 +277,8 @@ internal class TransfersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -302,7 +307,7 @@ internal class TransfersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Transfer>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -348,7 +353,8 @@ internal class TransfersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listTransfers(pageSize: Int? = nil, cursor: String? = nil, orderBy: OrderBy_listTransfers? = nil, direction: String? = nil, user: String? = nil, receiver: String? = nil, status: Status_listTransfers? = nil, minTimestamp: String? = nil, maxTimestamp: String? = nil, tokenType: String? = nil, tokenId: String? = nil, assetId: String? = nil, tokenAddress: String? = nil, tokenName: String? = nil, minQuantity: String? = nil, maxQuantity: String? = nil, metadata: String? = nil) async throws -> ListTransfersResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listTransfersWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, receiver: receiver, status: status, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp, tokenType: tokenType, tokenId: tokenId, assetId: assetId, tokenAddress: tokenAddress, tokenName: tokenName, minQuantity: minQuantity, maxQuantity: maxQuantity, metadata: metadata)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -357,7 +363,7 @@ internal class TransfersAPI {
                   return
                 }
 
-                requestTask = listTransfersWithRequestBuilder(pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, receiver: receiver, status: status, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp, tokenType: tokenType, tokenId: tokenId, assetId: assetId, tokenAddress: tokenAddress, tokenName: tokenName, minQuantity: minQuantity, maxQuantity: maxQuantity, metadata: metadata).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -366,8 +372,8 @@ internal class TransfersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -401,23 +407,23 @@ internal class TransfersAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "page_size": pageSize?.encodeToJSON(),
-            "cursor": cursor?.encodeToJSON(),
-            "order_by": orderBy?.encodeToJSON(),
-            "direction": direction?.encodeToJSON(),
-            "user": user?.encodeToJSON(),
-            "receiver": receiver?.encodeToJSON(),
-            "status": status?.encodeToJSON(),
-            "min_timestamp": minTimestamp?.encodeToJSON(),
-            "max_timestamp": maxTimestamp?.encodeToJSON(),
-            "token_type": tokenType?.encodeToJSON(),
-            "token_id": tokenId?.encodeToJSON(),
-            "asset_id": assetId?.encodeToJSON(),
-            "token_address": tokenAddress?.encodeToJSON(),
-            "token_name": tokenName?.encodeToJSON(),
-            "min_quantity": minQuantity?.encodeToJSON(),
-            "max_quantity": maxQuantity?.encodeToJSON(),
-            "metadata": metadata?.encodeToJSON(),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "cursor": (wrappedValue: cursor?.encodeToJSON(), isExplode: false),
+            "order_by": (wrappedValue: orderBy?.encodeToJSON(), isExplode: false),
+            "direction": (wrappedValue: direction?.encodeToJSON(), isExplode: false),
+            "user": (wrappedValue: user?.encodeToJSON(), isExplode: false),
+            "receiver": (wrappedValue: receiver?.encodeToJSON(), isExplode: false),
+            "status": (wrappedValue: status?.encodeToJSON(), isExplode: false),
+            "min_timestamp": (wrappedValue: minTimestamp?.encodeToJSON(), isExplode: false),
+            "max_timestamp": (wrappedValue: maxTimestamp?.encodeToJSON(), isExplode: false),
+            "token_type": (wrappedValue: tokenType?.encodeToJSON(), isExplode: false),
+            "token_id": (wrappedValue: tokenId?.encodeToJSON(), isExplode: false),
+            "asset_id": (wrappedValue: assetId?.encodeToJSON(), isExplode: false),
+            "token_address": (wrappedValue: tokenAddress?.encodeToJSON(), isExplode: false),
+            "token_name": (wrappedValue: tokenName?.encodeToJSON(), isExplode: false),
+            "min_quantity": (wrappedValue: minQuantity?.encodeToJSON(), isExplode: false),
+            "max_quantity": (wrappedValue: maxQuantity?.encodeToJSON(), isExplode: false),
+            "metadata": (wrappedValue: metadata?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -428,6 +434,6 @@ internal class TransfersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListTransfersResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/UsersAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/UsersAPI.swift
@@ -20,7 +20,8 @@ internal class UsersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getSignableRegistration(getSignableRegistrationRequest: GetSignableRegistrationRequest) async throws -> GetSignableRegistrationResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getSignableRegistrationWithRequestBuilder(getSignableRegistrationRequest: getSignableRegistrationRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +30,7 @@ internal class UsersAPI {
                   return
                 }
 
-                requestTask = getSignableRegistrationWithRequestBuilder(getSignableRegistrationRequest: getSignableRegistrationRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -38,8 +39,8 @@ internal class UsersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -65,7 +66,7 @@ internal class UsersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetSignableRegistrationResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -76,7 +77,8 @@ internal class UsersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getSignableRegistrationOffchain(getSignableRegistrationRequest: GetSignableRegistrationRequest) async throws -> GetSignableRegistrationOffchainResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getSignableRegistrationOffchainWithRequestBuilder(getSignableRegistrationRequest: getSignableRegistrationRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -85,7 +87,7 @@ internal class UsersAPI {
                   return
                 }
 
-                requestTask = getSignableRegistrationOffchainWithRequestBuilder(getSignableRegistrationRequest: getSignableRegistrationRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -94,8 +96,8 @@ internal class UsersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -121,7 +123,7 @@ internal class UsersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetSignableRegistrationOffchainResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -132,7 +134,8 @@ internal class UsersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getUsers(user: String) async throws -> GetUsersApiResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getUsersWithRequestBuilder(user: user)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -141,7 +144,7 @@ internal class UsersAPI {
                   return
                 }
 
-                requestTask = getUsersWithRequestBuilder(user: user).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -150,8 +153,8 @@ internal class UsersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -180,7 +183,7 @@ internal class UsersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetUsersApiResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -191,7 +194,8 @@ internal class UsersAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func registerUser(registerUserRequest: RegisterUserRequest) async throws -> RegisterUserResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = registerUserWithRequestBuilder(registerUserRequest: registerUserRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -200,7 +204,7 @@ internal class UsersAPI {
                   return
                 }
 
-                requestTask = registerUserWithRequestBuilder(registerUserRequest: registerUserRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -209,8 +213,8 @@ internal class UsersAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -236,6 +240,6 @@ internal class UsersAPI {
 
         let localVariableRequestBuilder: RequestBuilder<RegisterUserResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/APIs/WithdrawalsAPI.swift
+++ b/Sources/ImmutableXCore/Generated/APIs/WithdrawalsAPI.swift
@@ -22,7 +22,8 @@ internal class WithdrawalsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func createWithdrawal(xImxEthAddress: String, xImxEthSignature: String, createWithdrawalRequest: CreateWithdrawalRequest) async throws -> CreateWithdrawalResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = createWithdrawalWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createWithdrawalRequest: createWithdrawalRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -31,7 +32,7 @@ internal class WithdrawalsAPI {
                   return
                 }
 
-                requestTask = createWithdrawalWithRequestBuilder(xImxEthAddress: xImxEthAddress, xImxEthSignature: xImxEthSignature, createWithdrawalRequest: createWithdrawalRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -40,8 +41,8 @@ internal class WithdrawalsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -70,7 +71,7 @@ internal class WithdrawalsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<CreateWithdrawalResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -81,7 +82,8 @@ internal class WithdrawalsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getSignableWithdrawal(getSignableWithdrawalRequest: GetSignableWithdrawalRequest) async throws -> GetSignableWithdrawalResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = getSignableWithdrawalWithRequestBuilder(getSignableWithdrawalRequest: getSignableWithdrawalRequest)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -90,7 +92,7 @@ internal class WithdrawalsAPI {
                   return
                 }
 
-                requestTask = getSignableWithdrawalWithRequestBuilder(getSignableWithdrawalRequest: getSignableWithdrawalRequest).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -99,8 +101,8 @@ internal class WithdrawalsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -126,7 +128,7 @@ internal class WithdrawalsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<GetSignableWithdrawalResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "POST", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -137,7 +139,8 @@ internal class WithdrawalsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func getWithdrawal(id: String) async throws -> Withdrawal {
-        var requestTask: RequestTask?
+        let requestBuilder = getWithdrawalWithRequestBuilder(id: id)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -146,7 +149,7 @@ internal class WithdrawalsAPI {
                   return
                 }
 
-                requestTask = getWithdrawalWithRequestBuilder(id: id).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -155,8 +158,8 @@ internal class WithdrawalsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -185,7 +188,7 @@ internal class WithdrawalsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<Withdrawal>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 
     /**
@@ -213,7 +216,8 @@ internal class WithdrawalsAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     internal class func listWithdrawals(withdrawnToWallet: Bool? = nil, rollupStatus: String? = nil, pageSize: Int? = nil, cursor: String? = nil, orderBy: String? = nil, direction: String? = nil, user: String? = nil, status: String? = nil, minTimestamp: String? = nil, maxTimestamp: String? = nil, tokenType: String? = nil, tokenId: String? = nil, assetId: String? = nil, tokenAddress: String? = nil, tokenName: String? = nil, minQuantity: String? = nil, maxQuantity: String? = nil, metadata: String? = nil) async throws -> ListWithdrawalsResponse {
-        var requestTask: RequestTask?
+        let requestBuilder = listWithdrawalsWithRequestBuilder(withdrawnToWallet: withdrawnToWallet, rollupStatus: rollupStatus, pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp, tokenType: tokenType, tokenId: tokenId, assetId: assetId, tokenAddress: tokenAddress, tokenName: tokenName, minQuantity: minQuantity, maxQuantity: maxQuantity, metadata: metadata)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -222,7 +226,7 @@ internal class WithdrawalsAPI {
                   return
                 }
 
-                requestTask = listWithdrawalsWithRequestBuilder(withdrawnToWallet: withdrawnToWallet, rollupStatus: rollupStatus, pageSize: pageSize, cursor: cursor, orderBy: orderBy, direction: direction, user: user, status: status, minTimestamp: minTimestamp, maxTimestamp: maxTimestamp, tokenType: tokenType, tokenId: tokenId, assetId: assetId, tokenAddress: tokenAddress, tokenName: tokenName, minQuantity: minQuantity, maxQuantity: maxQuantity, metadata: metadata).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -231,8 +235,8 @@ internal class WithdrawalsAPI {
                     }
                 }
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            requestTask.cancel()
         }
     }
 
@@ -267,24 +271,24 @@ internal class WithdrawalsAPI {
 
         var localVariableUrlComponents = URLComponents(string: localVariableURLString)
         localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems([
-            "withdrawn_to_wallet": withdrawnToWallet?.encodeToJSON(),
-            "rollup_status": rollupStatus?.encodeToJSON(),
-            "page_size": pageSize?.encodeToJSON(),
-            "cursor": cursor?.encodeToJSON(),
-            "order_by": orderBy?.encodeToJSON(),
-            "direction": direction?.encodeToJSON(),
-            "user": user?.encodeToJSON(),
-            "status": status?.encodeToJSON(),
-            "min_timestamp": minTimestamp?.encodeToJSON(),
-            "max_timestamp": maxTimestamp?.encodeToJSON(),
-            "token_type": tokenType?.encodeToJSON(),
-            "token_id": tokenId?.encodeToJSON(),
-            "asset_id": assetId?.encodeToJSON(),
-            "token_address": tokenAddress?.encodeToJSON(),
-            "token_name": tokenName?.encodeToJSON(),
-            "min_quantity": minQuantity?.encodeToJSON(),
-            "max_quantity": maxQuantity?.encodeToJSON(),
-            "metadata": metadata?.encodeToJSON(),
+            "withdrawn_to_wallet": (wrappedValue: withdrawnToWallet?.encodeToJSON(), isExplode: false),
+            "rollup_status": (wrappedValue: rollupStatus?.encodeToJSON(), isExplode: false),
+            "page_size": (wrappedValue: pageSize?.encodeToJSON(), isExplode: false),
+            "cursor": (wrappedValue: cursor?.encodeToJSON(), isExplode: false),
+            "order_by": (wrappedValue: orderBy?.encodeToJSON(), isExplode: false),
+            "direction": (wrappedValue: direction?.encodeToJSON(), isExplode: false),
+            "user": (wrappedValue: user?.encodeToJSON(), isExplode: false),
+            "status": (wrappedValue: status?.encodeToJSON(), isExplode: false),
+            "min_timestamp": (wrappedValue: minTimestamp?.encodeToJSON(), isExplode: false),
+            "max_timestamp": (wrappedValue: maxTimestamp?.encodeToJSON(), isExplode: false),
+            "token_type": (wrappedValue: tokenType?.encodeToJSON(), isExplode: false),
+            "token_id": (wrappedValue: tokenId?.encodeToJSON(), isExplode: false),
+            "asset_id": (wrappedValue: assetId?.encodeToJSON(), isExplode: false),
+            "token_address": (wrappedValue: tokenAddress?.encodeToJSON(), isExplode: false),
+            "token_name": (wrappedValue: tokenName?.encodeToJSON(), isExplode: false),
+            "min_quantity": (wrappedValue: minQuantity?.encodeToJSON(), isExplode: false),
+            "max_quantity": (wrappedValue: maxQuantity?.encodeToJSON(), isExplode: false),
+            "metadata": (wrappedValue: metadata?.encodeToJSON(), isExplode: false),
         ])
 
         let localVariableNillableHeaders: [String: Any?] = [
@@ -295,6 +299,6 @@ internal class WithdrawalsAPI {
 
         let localVariableRequestBuilder: RequestBuilder<ListWithdrawalsResponse>.Type = OpenAPIClientAPI.requestBuilderFactory.getBuilder()
 
-        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters)
+        return localVariableRequestBuilder.init(method: "GET", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: false)
     }
 }

--- a/Sources/ImmutableXCore/Generated/Configuration.swift
+++ b/Sources/ImmutableXCore/Generated/Configuration.swift
@@ -12,4 +12,8 @@ internal class Configuration {
     // You must set it prior to encoding any dates, and it will only be read once.
     @available(*, unavailable, message: "To set a different date format, use CodableHelper.dateFormatter instead.")
     internal static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    /// Configures the range of HTTP status codes that will result in a successful response
+    ///
+    /// If a HTTP status code is outside of this range the response will be interpreted as failed.
+    internal static var successfulStatusCodeRange: Range = 200..<300
 }

--- a/Sources/ImmutableXCore/Generated/Extensions.swift
+++ b/Sources/ImmutableXCore/Generated/Extensions.swift
@@ -145,6 +145,17 @@ extension KeyedEncodingContainerProtocol {
         }
     }
 
+    internal mutating func encode(_ value: Decimal, forKey key: Self.Key) throws {
+        var mutableValue = value
+        let stringValue = NSDecimalString(&mutableValue, Locale(identifier: "en_US"))
+        try encode(stringValue, forKey: key)
+    }
+
+    internal mutating func encodeIfPresent(_ value: Decimal?, forKey key: Self.Key) throws {
+        if let value = value {
+            try encode(value, forKey: key)
+        }
+    }
 }
 
 extension KeyedDecodingContainerProtocol {
@@ -184,10 +195,32 @@ extension KeyedDecodingContainerProtocol {
         return map
     }
 
+    internal func decode(_ type: Decimal.Type, forKey key: Self.Key) throws -> Decimal {
+        let stringValue = try decode(String.self, forKey: key)
+        guard let decimalValue = Decimal(string: stringValue) else {
+            let context = DecodingError.Context(codingPath: [key], debugDescription: "The key \(key) couldn't be converted to a Decimal value")
+            throw DecodingError.typeMismatch(type, context)
+        }
+
+        return decimalValue
+    }
+
+    internal func decodeIfPresent(_ type: Decimal.Type, forKey key: Self.Key) throws -> Decimal? {
+        guard let stringValue = try decodeIfPresent(String.self, forKey: key) else {
+            return nil
+        }
+        guard let decimalValue = Decimal(string: stringValue) else {
+            let context = DecodingError.Context(codingPath: [key], debugDescription: "The key \(key) couldn't be converted to a Decimal value")
+            throw DecodingError.typeMismatch(type, context)
+        }
+
+        return decimalValue
+    }
+
 }
 
 extension HTTPURLResponse {
     var isStatusCodeSuccessful: Bool {
-        return (200 ..< 300).contains(statusCode)
+        return Configuration.successfulStatusCodeRange.contains(statusCode)
     }
 }

--- a/Sources/ImmutableXCore/Generated/OpenISO8601DateFormatter.swift
+++ b/Sources/ImmutableXCore/Generated/OpenISO8601DateFormatter.swift
@@ -18,6 +18,15 @@ internal class OpenISO8601DateFormatter: DateFormatter {
         return formatter
     }()
 
+    static let withoutTime: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
     private func setup() {
         calendar = Calendar(identifier: .iso8601)
         locale = Locale(identifier: "en_US_POSIX")
@@ -38,7 +47,10 @@ internal class OpenISO8601DateFormatter: DateFormatter {
     override internal func date(from string: String) -> Date? {
         if let result = super.date(from: string) {
             return result
+        } else if let result = OpenISO8601DateFormatter.withoutSeconds.date(from: string) {
+            return result
         }
-        return OpenISO8601DateFormatter.withoutSeconds.date(from: string)
+
+        return OpenISO8601DateFormatter.withoutTime.date(from: string)
     }
 }

--- a/Sources/ImmutableXCore/Generated/URLSessionImplementations.swift
+++ b/Sources/ImmutableXCore/Generated/URLSessionImplementations.swift
@@ -55,8 +55,8 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T> {
      */
     internal var taskCompletionShouldRetry: ((Data?, URLResponse?, Error?, @escaping (Bool) -> Void) -> Void)?
 
-    required internal init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:]) {
-        super.init(method: method, URLString: URLString, parameters: parameters, headers: headers)
+    required internal init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool) {
+        super.init(method: method, URLString: URLString, parameters: parameters, headers: headers, requiresAuthentication: requiresAuthentication)
     }
 
     /**


### PR DESCRIPTION
There were some minor internal Swift updates in the new version which would cause compiling issues when the command was run in the latest version of the generator.