### PR TITLE
feat: expose collections apis

### DIFF
--- a/Sources/ImmutableXCore/ImmutableX.swift
+++ b/Sources/ImmutableXCore/ImmutableX.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 // swiftlint:disable file_length
+// swiftlint:disable type_body_length
 public struct ImmutableX {
     /// A shared instance of ``ImmutableX`` that holds configuration for ``base``, ``logLevel`` and
     /// a set o utility methods for the most common workflows for the core SDK.
@@ -39,6 +40,7 @@ public struct ImmutableX {
     private let depositAPI: DepositsAPI.Type
     private let assetsAPI: AssetsAPI.Type
     private let collectionsAPI: CollectionsAPI.Type
+    private let projectsAPI: ProjectsAPI.Type
 
     /// Internal init method that includes dependencies. For the public facing API use ``initialize(base:logLevel:)``
     /// instead.
@@ -54,7 +56,8 @@ public struct ImmutableX {
         usersAPI: UsersAPI.Type = UsersAPI.self,
         depositAPI: DepositsAPI.Type = DepositsAPI.self,
         assetsAPI: AssetsAPI.Type = AssetsAPI.self,
-        collectionsAPI: CollectionsAPI.Type = CollectionsAPI.self
+        collectionsAPI: CollectionsAPI.Type = CollectionsAPI.self,
+        projectsAPI: ProjectsAPI.Type = ProjectsAPI.self
     ) {
         self.base = base
         self.logLevel = logLevel
@@ -68,6 +71,7 @@ public struct ImmutableX {
         self.depositAPI = depositAPI
         self.assetsAPI = assetsAPI
         self.collectionsAPI = collectionsAPI
+        self.projectsAPI = projectsAPI
     }
 
     /// Initializes the SDK with the given ``base`` and ``logLevel`` by assigning a shared instance accessible via
@@ -412,6 +416,50 @@ public struct ImmutableX {
                 blacklist: blacklist,
                 whitelist: whitelist,
                 keyword: keyword
+            )
+        }
+    }
+
+    /// Get a project
+    ///
+    /// - Parameters:
+    ///     - id: Project ID
+    ///     - signer: represents the users L1 wallet to get the address and sign the registration
+    /// - Returns: ``Project``
+    /// - Throws: A variation of ``ImmutableXError``
+    public func getProject(id: String, signer: Signer) async throws -> Project {
+        try await APIErrorMapper.map(caller: "Get Project") {
+            let (timestamp, signature) = try await IMXTimestamp.request(signer: signer)
+            return try await self.projectsAPI.getProject(id: id, iMXSignature: signature, iMXTimestamp: timestamp)
+        }
+    }
+
+    /// Get projects
+    ///
+    /// - Parameters:
+    ///     - pageSize: Page size of the result (optional)
+    ///     - cursor: Cursor (optional)
+    ///     - orderBy: Property to sort by (optional)
+    ///     - direction: Direction to sort (asc/desc) (optional)
+    ///     - signer: represents the users L1 wallet to get the address and sign the registration
+    /// - returns: ``GetProjectsResponse``
+    /// - Throws: A variation of ``ImmutableXError``
+    public func getProjects(
+        pageSize: Int? = nil,
+        cursor: String? = nil,
+        orderBy: String? = nil,
+        direction: String? = nil,
+        signer: Signer
+    ) async throws -> GetProjectsResponse {
+        try await APIErrorMapper.map(caller: "Get Projects") {
+            let (timestamp, signature) = try await IMXTimestamp.request(signer: signer)
+            return try await self.projectsAPI.getProjects(
+                iMXSignature: signature,
+                iMXTimestamp: timestamp,
+                pageSize: pageSize,
+                cursor: cursor,
+                orderBy: orderBy,
+                direction: direction
             )
         }
     }

--- a/Sources/ImmutableXCore/Utils/IMXTimestamp.swift
+++ b/Sources/ImmutableXCore/Utils/IMXTimestamp.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct IMXTimestamp {
+    /// Generic helper for API's that require a signed timestamp as a parameter.
+    ///
+    /// https://docs.x.immutable.com/docs/generate-imx-signature/
+    static func request(
+        signer: Signer,
+        date: Date = Date()
+    ) async throws -> (timestamp: String, signature: String) {
+        let stringSeconds = "\(date.timeIntervalSince1970)"
+        let seconds = String(stringSeconds.prefix(while: { $0 != "." }))
+        let signature = try await signer.signMessage(seconds)
+        return (timestamp: seconds, signature: CryptoUtil.serializeEthSignature(signature))
+    }
+}

--- a/Tests/ImmutableXCoreTests/ImmutableXTests.swift
+++ b/Tests/ImmutableXCoreTests/ImmutableXTests.swift
@@ -12,6 +12,7 @@ final class ImmutableXTests: XCTestCase {
     let depositAPIMock = DepositAPIMock.self
     let assetsAPIMock = AssetsAPIMock.self
     let collectionsAPIMock = CollectionsAPIMock.self
+    let projectsAPIMock = ProjectsAPIMock.self
 
     lazy var core = ImmutableX(
         buyWorkflow: buyWorkflow,
@@ -23,7 +24,8 @@ final class ImmutableXTests: XCTestCase {
         usersAPI: usersAPIMock,
         depositAPI: depositAPIMock,
         assetsAPI: assetsAPIMock,
-        collectionsAPI: collectionsAPIMock
+        collectionsAPI: collectionsAPIMock,
+        projectsAPI: projectsAPIMock
     )
 
     override func setUp() {
@@ -38,6 +40,7 @@ final class ImmutableXTests: XCTestCase {
         depositAPIMock.resetMock()
         assetsAPIMock.resetMock()
         collectionsAPIMock.resetMock()
+        projectsAPIMock.resetMock()
 
         ImmutableX.initialize()
 
@@ -96,6 +99,14 @@ final class ImmutableXTests: XCTestCase {
         let listCollectionsCompanion = CollectionsAPIMock.ListCollectionsCompanion()
         listCollectionsCompanion.returnValue = listCollectionResponseStub1
         collectionsAPIMock.mock(listCollectionsCompanion)
+
+        let getProjectCompanion = ProjectsAPIMock.GetProjectCompanion()
+        getProjectCompanion.returnValue = projectStub1
+        projectsAPIMock.mock(getProjectCompanion)
+
+        let getProjectsCompanion = ProjectsAPIMock.GetProjectsCompanion()
+        getProjectsCompanion.returnValue = getProjectResponseStub1
+        projectsAPIMock.mock(getProjectsCompanion)
     }
 
     func testSdkVersion() {
@@ -340,6 +351,38 @@ final class ImmutableXTests: XCTestCase {
 
         await XCTAssertThrowsErrorAsync {
             _ = try await core.listCollections()
+        }
+    }
+
+    // MARK: - Projects
+
+    func testGetProjectSuccess() async throws {
+        let response = try await core.getProject(id: "id", signer: SignerMock())
+        XCTAssertEqual(response, projectStub1)
+    }
+
+    func testGetProjectFailure() async {
+        let companion = ProjectsAPIMock.GetProjectCompanion()
+        companion.throwableError = DummyError.something
+        projectsAPIMock.mock(companion)
+
+        await XCTAssertThrowsErrorAsync {
+            _ = try await core.getProject(id: "id", signer: SignerMock())
+        }
+    }
+
+    func testGetProjectsSuccess() async throws {
+        let response = try await core.getProjects(signer: SignerMock())
+        XCTAssertEqual(response, getProjectResponseStub1)
+    }
+
+    func testGetProjectsFailure() async {
+        let companion = ProjectsAPIMock.GetProjectsCompanion()
+        companion.throwableError = DummyError.something
+        projectsAPIMock.mock(companion)
+
+        await XCTAssertThrowsErrorAsync {
+            _ = try await core.getProjects(signer: SignerMock())
         }
     }
 }

--- a/Tests/ImmutableXCoreTests/Mocks/API/ProjectsAPIMock.swift
+++ b/Tests/ImmutableXCoreTests/Mocks/API/ProjectsAPIMock.swift
@@ -1,0 +1,61 @@
+import Foundation
+@testable import ImmutableXCore
+
+final class ProjectsAPIMock: ProjectsAPI {
+    class GetProjectCompanion {
+        var throwableError: Error?
+        var callsCount = 0
+        var returnValue: Project!
+    }
+
+    class GetProjectsCompanion {
+        var throwableError: Error?
+        var callsCount = 0
+        var returnValue: GetProjectsResponse!
+    }
+
+    static var getProjectCompanion: GetProjectCompanion?
+    static var getProjectsCompanion: GetProjectsCompanion?
+
+    static func mock(_ companion: GetProjectCompanion) {
+        getProjectCompanion = companion
+    }
+
+    static func mock(_ companion: GetProjectsCompanion) {
+        getProjectsCompanion = companion
+    }
+
+    static func resetMock() {
+        getProjectCompanion = nil
+        getProjectsCompanion = nil
+    }
+
+    override class func getProject(id: String, iMXSignature: String, iMXTimestamp: String) async throws -> Project {
+        let companion = getProjectCompanion!
+        companion.callsCount += 1
+
+        if let error = companion.throwableError {
+            throw error
+        }
+
+        return companion.returnValue
+    }
+
+    override class func getProjects(
+        iMXSignature: String,
+        iMXTimestamp: String,
+        pageSize: Int? = nil,
+        cursor: String? = nil,
+        orderBy: String? = nil,
+        direction: String? = nil
+    ) async throws -> GetProjectsResponse {
+        let companion = getProjectsCompanion!
+        companion.callsCount += 1
+
+        if let error = companion.throwableError {
+            throw error
+        }
+
+        return companion.returnValue
+    }
+}

--- a/Tests/ImmutableXCoreTests/Mocks/Stubs/Models.swift
+++ b/Tests/ImmutableXCoreTests/Mocks/Stubs/Models.swift
@@ -238,3 +238,22 @@ let listCollectionResponseStub1 = ListCollectionsResponse(
     remaining: 0,
     result: [collectionStub1]
 )
+
+let projectStub1 = Project(
+    collectionLimitExpiresAt: "",
+    collectionMonthlyLimit: 1,
+    collectionRemaining: 1,
+    companyName: "companyName",
+    contactEmail: "email",
+    id: 1,
+    mintLimitExpiresAt: "",
+    mintMonthlyLimit: 1,
+    mintRemaining: 1,
+    name: "Proj"
+)
+
+let getProjectResponseStub1 = GetProjectsResponse(
+    cursor: "",
+    remaining: 0,
+    result: [projectStub1]
+)

--- a/Tests/ImmutableXCoreTests/Utils/IMXTimestampTests.swift
+++ b/Tests/ImmutableXCoreTests/Utils/IMXTimestampTests.swift
@@ -1,0 +1,26 @@
+@testable import ImmutableXCore
+import XCTest
+
+final class IMXTimestampTests: XCTestCase {
+    let returnSignature = "0xc5b53280e17b53d130eed7f00fc4270c29910fc30445af60dbb6abd82dc98f5923fb2fa2" +
+        "a8940c1d6d871c984f19954d25d913857e798d0c8f3fe98b57e7bcb61c"
+    let expectedSerializedSignature = "0xc5b53280e17b53d130eed7f00fc4270c29910fc30445af60dbb6abd82dc98f5923fb2fa2" +
+        "a8940c1d6d871c984f19954d25d913857e798d0c8f3fe98b57e7bcb601"
+
+    func testRequest() async throws {
+        let signer = SignerMock()
+        signer.signMessageReturnValue = returnSignature
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        let date = try XCTUnwrap(dateFormatter.date(from: "2016-01-23T12:34:56Z"))
+
+        let (timestamp, signature) = try await IMXTimestamp.request(signer: signer, date: date)
+
+        XCTAssertEqual(signer.signMessageReceivedMessage, "1453552496")
+        XCTAssertEqual(timestamp, "1453552496")
+        XCTAssertEqual(signature, expectedSerializedSignature)
+    }
+}


### PR DESCRIPTION
- Get a project
- Get projects

Both apis make use of the newly created IMXTimestamp, that signs on a timestamp as a requirement from the API.