### PR TITLE
refactor: rename StarkKey generateKeyPair method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ Ropsten has been deprecated and won't work anymore. Sandbox is the preferred tes
 - (Breaking): rename PrivateKey, PublicKey, KeyPair and CurvePoint to ECPrivateKey, ECPublicKey, ECKeyPair and ECCurvePoint respectively
 The previous names were too generic and would easily conflict with other classes/structs. These have then been prefixed with EC for Elliptic Curve.
 
+- (Breaking): rename StarkKey's generateKeyPair to generateLegacyKeyPair
+This keypair generation is specific to ImmutableX's Link and should be used only for compatibility reasons.
+
 ### Fixed
 
 - re-include macos as a Cocoapods target
@@ -49,6 +52,8 @@ The Core SDK is generic enough that it should work on macOS. It had accidentally
 ## [0.3.1] - 2022-10-19
 
 ### Removed
+
+- (Breaking): remove StarkKey's generateKeyPairFromRawSignature method from public interface 
 
 - version file
 

--- a/Sources/ImmutableXCore/Crypto/Stark/StarkKey.swift
+++ b/Sources/ImmutableXCore/Crypto/Stark/StarkKey.swift
@@ -15,7 +15,7 @@ public extension StarkKey {
     /// - Parameter signer: the signer that the key pair will be derived from
     /// - Returns: Stark key pair as ``ECKeyPair``
     /// - Throws: ``ImmutableXError``
-    static func generateKeyPair(from signer: Signer) async throws -> ECKeyPair {
+    static func generateLegacyKeyPair(from signer: Signer) async throws -> ECKeyPair {
         let address = try await signer.getAddress()
         let signature = try await signer.signMessage(Constants.starkMessage)
         return try generateKeyPairFromRawSignature(signature, ethereumAddress: address)
@@ -26,7 +26,10 @@ public extension StarkKey {
     /// - Parameter ethereumAddress: the connected wallet address
     /// - Returns: Stark key pair as ``ECKeyPair``
     /// - Throws: ``ImmutableXError``
-    static func generateKeyPairFromRawSignature(_ signature: String, ethereumAddress: String) throws -> ECKeyPair {
+    internal static func generateKeyPairFromRawSignature(
+        _ signature: String,
+        ethereumAddress: String
+    ) throws -> ECKeyPair {
         // swiftlint:disable:next line_length
         // https://github.com/ethers-io/ethers.js/blob/3de1b815014b10d223a42e524fe9c25f9087293b/packages/bytes/src.ts/index.ts#L347
         let seed = signature.dropHexPrefix[64 ..< 128]

--- a/Tests/ImmutableXCoreTests/Crypto/Stark/StarkKeyTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/Stark/StarkKeyTests.swift
@@ -54,7 +54,7 @@ final class StarkKeyTests: XCTestCase {
         signer.signMessageReturnValue = "0x5a263fad6f17f23e7c7ea833d058f3656d3fe464baf13f6f5ccba9a246" +
             "6ba2ce4c4a250231bcac7beb165aec4c9b049b4ba40ad8dd287dc79b92b1ffcf20cdcf1b"
 
-        let pair = try await StarkKey.generateKeyPair(from: signer)
+        let pair = try await StarkKey.generateLegacyKeyPair(from: signer)
         XCTAssertEqual(
             pair.publicKey.asStarkPublicKey,
             "0x02a4c7332c55d6c1c510d24272d1db82878f2302f05b53bcc38695ed5f78fffd"
@@ -67,7 +67,7 @@ final class StarkKeyTests: XCTestCase {
         signer.signMessageThrowableError = ImmutableXError.invalidKeyData
 
         do {
-            _ = try await StarkKey.generateKeyPair(from: signer)
+            _ = try await StarkKey.generateLegacyKeyPair(from: signer)
             XCTFail("Expected to throw while awaiting, but succeeded")
         } catch {
             XCTAssertTrue(error is ImmutableXError)


### PR DESCRIPTION
# Summary
- Rename StarkKey generateKeyPair method
- Remove StarkKey's generateKeyPairFromRawSignature method from public interface.
# Why the changes
This keypair generation is specific to ImmutableX's Link and should be used only for compatibility reasons.

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    n/a
