### PR TITLE
feat: generate random stark key pair 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `getUser(ethAddress:)` has been added to ImmutableX instance.
+- `generateKeyPair()` method has been added to `StarkKey` for generating random key pairs.
 
 ### Changed
 

--- a/Sources/ImmutableXCore/Crypto/Stark/StarkCurve.swift
+++ b/Sources/ImmutableXCore/Crypto/Stark/StarkCurve.swift
@@ -126,3 +126,19 @@ extension StarkCurve {
         return ECCurvePoint(x: x3, y: y3)
     }
 }
+
+extension StarkCurve {
+    /// Generates a random private key
+    static func generatePrivateKey() -> ECPrivateKey {
+        let byteCount = (StarkCurve.N - 1).as256bitLongData().bytes.count
+        var privateKey: ECPrivateKey?
+
+        repeat {
+            // Generate random bytes within the Stark Curve range
+            guard let randomBytes = try? CryptoUtil.generateRandomBytes(count: byteCount) else { continue }
+            privateKey = try? ECPrivateKey(number: BigInt(data: Data(randomBytes)))
+        } while privateKey == nil
+
+        return privateKey!
+    }
+}

--- a/Sources/ImmutableXCore/Crypto/Stark/StarkKey.swift
+++ b/Sources/ImmutableXCore/Crypto/Stark/StarkKey.swift
@@ -21,6 +21,17 @@ public extension StarkKey {
         return try generateKeyPairFromRawSignature(signature, ethereumAddress: address)
     }
 
+    /// Generates a new Stark key pair
+    /// - Returns: Stark key pair as ``ECKeyPair``
+    /// - Throws: ``ImmutableXError``
+    static func generateKeyPair() throws -> ECKeyPair {
+        let newKey = StarkCurve.generatePrivateKey()
+        let unbiasedKey = grindKey(keySeed: newKey.number.asHexString())
+        let privateKey = try ECPrivateKey(hex: unbiasedKey)
+        let publicKey = try ECPublicKey(privateKey: privateKey)
+        return ECKeyPair(private: privateKey, public: publicKey)
+    }
+
     /// Generate a Stark key pair from a L1 wallet.
     /// - Parameter signature: the 's' variable of the signature
     /// - Parameter ethereumAddress: the connected wallet address

--- a/Sources/ImmutableXCore/Utils/CryptoUtil.swift
+++ b/Sources/ImmutableXCore/Utils/CryptoUtil.swift
@@ -92,4 +92,19 @@ struct CryptoUtil {
                 importRecoveryParam(v).padLeft(length: 2)
         ).addHexPrefix
     }
+
+    /// Generates an array of cryptographically secure random bytes.
+    /// - Parameter count: the number of random bytes to return in the array
+    /// - Returns: an array random bytes
+    /// - Throws: ``ImmutableXError/invalidPrivateKey`` if could not generate bytes
+    static func generateRandomBytes(count: Int) throws -> [UInt8] {
+        var randomBytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &randomBytes)
+
+        if status != errSecSuccess {
+            throw ImmutableXError.invalidPrivateKey
+        }
+
+        return randomBytes
+    }
 }

--- a/Sources/ImmutableXCore/Utils/ImmutableXError.swift
+++ b/Sources/ImmutableXCore/Utils/ImmutableXError.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 public enum ImmutableXError: Error {
+    /// Error related to generating an ``ECPrivateKey``
+    case invalidPrivateKey
+
     /// Error related to deriving or parsing ``ECPrivateKey`` and ``ECPublicKey``
     case invalidKeyData
 

--- a/Tests/ImmutableXCoreTests/Crypto/Stark/StarkCurveTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/Stark/StarkCurveTests.swift
@@ -80,4 +80,11 @@ final class StarkCurveTests: XCTestCase {
             StarkCurve.multiply(StarkCurve.G, by: BigInt(5))
         )
     }
+
+    func testGeneratePrivateKey() throws {
+        let pair1 = StarkCurve.generatePrivateKey()
+        let pair2 = StarkCurve.generatePrivateKey()
+
+        XCTAssertNotEqual(pair1, pair2)
+    }
 }

--- a/Tests/ImmutableXCoreTests/Crypto/Stark/StarkKeyTests.swift
+++ b/Tests/ImmutableXCoreTests/Crypto/Stark/StarkKeyTests.swift
@@ -73,6 +73,13 @@ final class StarkKeyTests: XCTestCase {
             XCTAssertTrue(error is ImmutableXError)
         }
     }
+
+    func testGenerateKeyPair() throws {
+        let pair1 = try StarkKey.generateKeyPair()
+        let pair2 = try StarkKey.generateKeyPair()
+
+        XCTAssertNotEqual(pair1, pair2)
+    }
 }
 
 extension StarkKeyTests {

--- a/Tests/ImmutableXCoreTests/Utils/CryptoUtilTests.swift
+++ b/Tests/ImmutableXCoreTests/Utils/CryptoUtilTests.swift
@@ -72,4 +72,12 @@ final class CryptoUtilTests: XCTestCase {
                 "c1bc021cd318c734c51ae29374f2beb0e6f2dd49b4bf401"
         )
     }
+
+    func testGenerateRandomBytes() throws {
+        let bytes1 = try CryptoUtil.generateRandomBytes(count: 12)
+        let bytes2 = try CryptoUtil.generateRandomBytes(count: 12)
+        XCTAssertEqual(bytes1.count, 12)
+        XCTAssertEqual(bytes2.count, 12)
+        XCTAssertNotEqual(bytes1, bytes2)
+    }
 }


### PR DESCRIPTION
# Summary
Generates a random stark key pair by generating an array of cryptographically secure random bytes as a seed to the Stark Curve range. The outcome is then ground to remove any type os bias from the key.
# Why the changes
As part of the v1 interface agreement

# Things worth calling out

# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
n/a
