### PR TITLE
ci: only publish to cocoapods if version tag

### DIFF
--- a/.github/workflows/publish_cocoapods.yml
+++ b/.github/workflows/publish_cocoapods.yml
@@ -3,7 +3,7 @@ name: Publish Cocoapods
 on:
   push:
     tags:
-      - '*'
+      - "v*.*.*"
 
 jobs:
   publish_cocoapods:


### PR DESCRIPTION
# Summary
This ensure that other tags, including testing tags are ignored.

# Why the changes
I'd like to create a temporary test flag to test the beta format with SPM without releasing to Cocoapods.

# Things worth calling out
# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    n/a