### PR TITLE
[DX-2500]: Update CODEOWNERS and add deprecation banner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @immutable/sdk
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 ---
 
+# 🚨 This library is no longer maintained 🚨
+
+If you're building apps with Immutable, please use [Immutable's Unified SDK](https://github.com/immutable/ts-immutable-sdk)
+
 # ImmutableX Core SDK Swift
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/a7887f9758562e49b171/maintainability)](https://codeclimate.com/repos/62be55bacb1f54014d00579d/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/a7887f9758562e49b171/test_coverage)](https://codeclimate.com/repos/62be55bacb1f54014d00579d/test_coverage)


### PR DESCRIPTION
# Summary
Update CODEOWNERS and add deprecation banner

# Why the changes
To ensure this repo has a code owner.
Also to direct users to the new SDK.

# Things worth calling out
No code changes

# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
