### PR TITLE
chore(release): v1.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0-beta.2] - 2024-02-15
 
-### Added
-
-for new features.
-
-### Changed
-
-for changes in existing functionality.
-
-### Deprecated
-
-for soon-to-be removed features.
-
-### Removed
-
-for removed features.
-
-### Fixed
-
-for any bug fixes.
+This SDK has been deprecated. If you're building apps with Immutable, please use [Immutable's Unified SDK](https://github.com/immutable/ts-immutable-sdk)
 
 ## [1.0.0-beta.1] - 2022-11-28
 

--- a/ImmutableXCore.podspec
+++ b/ImmutableXCore.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |spec|
     spec.name                  = 'ImmutableXCore'
-    spec.version               = '1.0.0-beta.1'
-    spec.summary               = 'The ImmutableX Core SDK Swift for applications written on the ImmutableX platform.'
+    spec.version               = '1.0.0-beta.2'
+    spec.summary               = 'The ImmutableX Core SDK Swift for applications has been deprecated.'
 
     spec.description           = <<-DESC
-    The Immutable Core SDK Swift provides convenient access to the Immutable API's for applications written on the ImmutableX platform.
+    The Immutable Core SDK Swift has been deperecated. Please use Immutable's Unified SDK instead.
                      DESC
 
     spec.homepage              = 'https://github.com/immutable/imx-core-sdk-swift'

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/immutable/imx-core-sdk-swift.git", from: "1.0.0-beta.1")
+    .package(url: "https://github.com/immutable/imx-core-sdk-swift.git", from: "1.0.0-beta.2")
 ]
 ```
 

--- a/Sources/ImmutableXCore/ImmutableX.swift
+++ b/Sources/ImmutableXCore/ImmutableX.swift
@@ -28,7 +28,7 @@ public struct ImmutableX {
     public var logLevel: ImmutableXHTTPLoggingLevel
 
     /// Returns the version of the sdk
-    internal var sdkVersion: String = "1.0.0-beta.1"
+    internal var sdkVersion: String = "1.0.0-beta.2"
 
     private let createTradeWorkflow: CreateTradeWorkflow.Type
     private let createOrderWorkflow: CreateOrderWorkflow.Type

--- a/Tests/ImmutableXCoreTests/ImmutableXTests.swift
+++ b/Tests/ImmutableXCoreTests/ImmutableXTests.swift
@@ -187,7 +187,7 @@ final class ImmutableXTests: XCTestCase {
     }
 
     func testSdkVersion() {
-        XCTAssertEqual(ImmutableX.shared.sdkVersion, "1.0.0-beta.1")
+        XCTAssertEqual(ImmutableX.shared.sdkVersion, "1.0.0-beta.2")
     }
 
     func testInitialize() {


### PR DESCRIPTION
# Summary
v1.0.0-beta.2 - Mark this SDK as deprecated.

# Why the changes
A new release that adds a deprecation note to the SDK's description

# Things worth calling out
No behavioural changes

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
